### PR TITLE
Bug fix: Update Secret annotation valid after time

### DIFF
--- a/internal/yale/rotate.go
+++ b/internal/yale/rotate.go
@@ -179,7 +179,10 @@ func (m *Yale) UpdateKey(gskSpec apiv1b1.GCPSaKeySpec, namespace string) error {
 	}
 	// Create annotations for new key
 	newAnnotations := createAnnotations(*Key)
+	// Record old key's name for tracking
 	newAnnotations["oldServiceAccountKeyName"] = originalAnnotations["serviceAccountKeyName"]
+	// Update valid after date to new key validAfterTime
+	newAnnotations["validAfterDate"] = Key.validAfterTime
 	K8Secret.ObjectMeta.SetAnnotations(newAnnotations)
 
 	saKey, err := base64.StdEncoding.DecodeString(Key.privateKeyData)


### PR DESCRIPTION
Bug fix. Since secret annotation, ```validAfterDate``` wasn't being updated after each key rotation, Yale kept rotating key based on the first key that was made. 