### PR TITLE
[DDO-2771] New library for computing cutoff times

### DIFF
--- a/internal/yale/cutoff/cutoff.go
+++ b/internal/yale/cutoff/cutoff.go
@@ -1,0 +1,95 @@
+package cutoff
+
+import (
+	apiv1b1 "github.com/broadinstitute/yale/internal/yale/crd/api/v1beta1"
+	"github.com/broadinstitute/yale/internal/yale/logs"
+	"time"
+)
+
+// minimums - the minimum supported value for a GSK's RotateAfter/DisableAfter/DeleteAfter
+// attributes. If a user sets, for example, a RotateAfter value of 3, it will be rounded up to this minimum.
+//
+// Note that we should always choose minimum windows to account for delays in the API data that we use to
+// determine if a key is still in use.
+// With Cloud Monitoring Metrics, data can lag up to 6 hours behind realtime; 7 days is a very generous buffer.
+var minimums = struct {
+	RotateAfter  int
+	DisableAfter int
+	DeleteAfter  int
+}{
+	RotateAfter:  7,
+	DisableAfter: 7,
+	DeleteAfter:  3,
+}
+
+// oneDay time.Duration representing time in a single day
+const oneDay = 24 * time.Hour
+
+type cutoffs struct {
+	gsk apiv1b1.GCPSaKey
+	now time.Time
+}
+
+type Cutoffs interface {
+	// ShouldRotate Return true if the key created at the given timestamp should be rotated
+	ShouldRotate(createdAt time.Time) bool
+	// ShouldDisable Return true if the key rotated at the given timestamp should be disabled
+	ShouldDisable(rotatedAt time.Time) bool
+	// ShouldDelete Return true if the key disabled at the given timestamp should be deleted
+	ShouldDelete(disabledAt time.Time) bool
+}
+
+func New(gsk apiv1b1.GCPSaKey) Cutoffs {
+	return cutoffs{
+		gsk: gsk,
+		now: time.Now(),
+	}
+}
+
+// ShouldRotate Return true if the key created at the given timestamp should be rotated
+func (c cutoffs) ShouldRotate(createdAt time.Time) bool {
+	return createdAt.Before(c.rotateCutoff())
+}
+
+func (c cutoffs) ShouldDisable(rotatedAt time.Time) bool {
+	return rotatedAt.Before(c.disableCutoff())
+}
+
+func (c cutoffs) ShouldDelete(disabledAt time.Time) bool {
+	return disabledAt.Before(c.deleteCutoff())
+}
+
+// rotateCutoff keys created before this timestamp should be rotated
+func (c cutoffs) rotateCutoff() time.Time {
+	return c.computeCutoff(c.gsk.Spec.KeyRotation.RotateAfter, minimums.RotateAfter, "RotateAfter")
+}
+
+// disableCutoff keys rotated before this timestamp should be disabled (if they are unused)
+func (c cutoffs) disableCutoff() time.Time {
+	return c.computeCutoff(c.gsk.Spec.KeyRotation.DisableAfter, minimums.DisableAfter, "DisableAfter")
+}
+
+// deleteCutoff keys disabled before this timestamp should be deleted
+func (c cutoffs) deleteCutoff() time.Time {
+	return c.computeCutoff(c.gsk.Spec.KeyRotation.DeleteAfter, minimums.DeleteAfter, "DeleteAfter")
+}
+
+// computeCutoff compute a cutoff date N days in the past
+func (c cutoffs) computeCutoff(ageDays int, minDays int, attrName string) time.Time {
+	ageDays = c.ensureMininum(ageDays, minDays, attrName)
+	return c.daysAgo(ageDays)
+}
+
+// ensureMinimum given a number of days, if it's less than minOperationWindowDays, round it up to the min and log a warning
+func (c cutoffs) ensureMininum(ageDays int, minDays int, attrName string) int {
+	if ageDays < minDays {
+		logs.Warn.Printf("%s in %s: %s has invalid value %d, will round up to %d", c.gsk.Name, c.gsk.Namespace, attrName, ageDays, minDays)
+		return minDays
+	}
+	return ageDays
+}
+
+// daysAgo return a timestamp that is n days in the past
+func (c cutoffs) daysAgo(n int) time.Time {
+	return c.now.Add(-1 * time.Duration(int64(n)*int64(oneDay)))
+}

--- a/internal/yale/cutoff/cutoff_test.go
+++ b/internal/yale/cutoff/cutoff_test.go
@@ -1,0 +1,136 @@
+package cutoff
+
+import (
+	"github.com/broadinstitute/yale/internal/yale/crd/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+	"time"
+)
+
+func Test_Cutoff_Timestamps(t *testing.T) {
+	layout := time.RFC3339
+	now, err := time.Parse(layout, "2023-04-28T09:10:11Z")
+	require.NoError(t, err)
+
+	type cutoffTimes struct {
+		rotateCutoff  string
+		disableCutoff string
+		deleteCutoff  string
+	}
+
+	type shouldChecks struct {
+		input   string
+		rotate  bool
+		disable bool
+		delete  bool
+	}
+
+	testCases := []struct {
+		name            string
+		input           v1beta1.KeyRotation
+		expectedCutoffs cutoffTimes
+		shouldChecks    []shouldChecks
+	}{
+		{
+			name: "should round up to configured minimums",
+			input: v1beta1.KeyRotation{
+				RotateAfter:  -1,
+				DisableAfter: 0,
+				DeleteAfter:  1,
+			},
+			expectedCutoffs: cutoffTimes{
+				rotateCutoff:  "2023-04-21T09:10:11Z",
+				disableCutoff: "2023-04-21T09:10:11Z",
+				deleteCutoff:  "2023-04-25T09:10:11Z",
+			},
+			shouldChecks: []shouldChecks{
+				{
+					input:   "2023-04-14T09:05:11Z",
+					rotate:  true,
+					disable: true,
+					delete:  true,
+				},
+				{
+					input:   "2023-04-21T09:15:11Z",
+					rotate:  false,
+					disable: false,
+					delete:  true,
+				},
+				{
+					input:   "2023-04-25T09:11:11Z",
+					rotate:  false,
+					disable: false,
+					delete:  false,
+				},
+			},
+		},
+		{
+			name: "should return correct cutoffs for values above minimums",
+			input: v1beta1.KeyRotation{
+				RotateAfter:  17,
+				DisableAfter: 16,
+				DeleteAfter:  8,
+			},
+			expectedCutoffs: cutoffTimes{
+				rotateCutoff:  "2023-04-11T09:10:11Z",
+				disableCutoff: "2023-04-12T09:10:11Z",
+				deleteCutoff:  "2023-04-20T09:10:11Z",
+			},
+			shouldChecks: []shouldChecks{
+				{
+					input:   "2023-04-23T00:00:00Z",
+					rotate:  false,
+					disable: false,
+					delete:  false,
+				},
+				{
+					input:   "2023-04-15T09:00:00Z",
+					rotate:  false,
+					disable: false,
+					delete:  true,
+				},
+				{
+					input:   "2023-04-11T09:30:00Z",
+					rotate:  false,
+					disable: true,
+					delete:  true,
+				},
+				{
+					input:   "2023-04-11T08:59:00Z",
+					rotate:  true,
+					disable: true,
+					delete:  true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gsk := v1beta1.GCPSaKey{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gsk",
+					Namespace: "test-namespace",
+				},
+				Spec: v1beta1.GCPSaKeySpec{
+					KeyRotation: tc.input,
+				},
+			}
+			c := &cutoffs{gsk, now}
+			assert.Equal(t, tc.expectedCutoffs.rotateCutoff, c.rotateCutoff().Format(layout))
+			assert.Equal(t, tc.expectedCutoffs.disableCutoff, c.disableCutoff().Format(layout))
+			assert.Equal(t, tc.expectedCutoffs.deleteCutoff, c.deleteCutoff().Format(layout))
+
+			for _, sc := range tc.shouldChecks {
+				timestamp, err := time.Parse(layout, sc.input)
+				require.NoError(t, err, "input: %q", sc.input)
+
+				assert.Equal(t, sc.rotate, c.ShouldRotate(timestamp), "input: %q", sc.input)
+				assert.Equal(t, sc.disable, c.ShouldDisable(timestamp), "input: %q", sc.input)
+				assert.Equal(t, sc.delete, c.ShouldDelete(timestamp), "input: %q", sc.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new library with test coverage that can be used to determine if a given service account key should be rotated, disabled, or deleted.

### Testing

This PR includes unit test coverage.

### Risk Assessment: Low

Adds a tested library that will be put to use in a subsequent PR.