### PR TITLE
[DDO-2771] New `keyops` package wrapping key API calls

### DIFF
--- a/internal/yale/authmetrics/authmetrics.go
+++ b/internal/yale/authmetrics/authmetrics.go
@@ -1,4 +1,4 @@
-package main
+package authmetrics
 
 import (
 	"context"

--- a/internal/yale/authmetrics/authmetrics_test.go
+++ b/internal/yale/authmetrics/authmetrics_test.go
@@ -1,4 +1,4 @@
-package main
+package authmetrics
 
 import (
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"

--- a/internal/yale/keyops/keyops.go
+++ b/internal/yale/keyops/keyops.go
@@ -1,0 +1,143 @@
+package keyops
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/broadinstitute/yale/internal/yale/logs"
+	"google.golang.org/api/iam/v1"
+	"strings"
+)
+
+// KEY_ALGORITHM what key algorithm to use when creating new Google SA keys
+const KEY_ALGORITHM string = "KEY_ALG_RSA_2048"
+
+// KEY_FORMAT format to use when creating new Google SA keys
+const KEY_FORMAT string = "TYPE_GOOGLE_CREDENTIALS_FILE"
+
+// Key represents a Google IAM service account key
+type Key struct {
+	// Project name of the project that owns the service account the key belongs to
+	Project string
+	// ServiceAccountEmail email for the service account that owns the key
+	ServiceAccountEmail string
+	// ID alphanumeric ID for the key
+	ID string
+}
+
+// Keyops peforms operations on Google service account keys. It supports
+// creating new keys, disabling, and deleting them.
+type Keyops interface {
+	// Create a new service account key for the given service account
+	// returns a Key instance that includes the new key's ID as well as the key's JSON private key data
+	Create(project string, serviceAccountEmail string) (Key, []byte, error)
+	// IsDisabled return true if the given key is enabled, false otherwise
+	IsDisabled(key Key) (bool, error)
+	// EnsureDisabled check if the key is enabled and if so, disable it
+	EnsureDisabled(key Key) error
+	// Delete the service account key
+	Delete(key Key) error
+}
+
+func New(iamService *iam.Service) Keyops {
+	return &keyops{
+		iam: iamService,
+	}
+}
+
+type keyops struct {
+	iam *iam.Service
+}
+
+func (k *keyops) Create(project string, serviceAccountEmail string) (Key, []byte, error) {
+	name := qualifiedServiceAccountName(project, serviceAccountEmail)
+	ctx := context.Background()
+	request := &iam.CreateServiceAccountKeyRequest{
+		KeyAlgorithm:   KEY_ALGORITHM,
+		PrivateKeyType: KEY_FORMAT,
+	}
+
+	logs.Info.Printf("creating new service account for %s...", serviceAccountEmail)
+	newKey, err := k.iam.Projects.ServiceAccounts.Keys.Create(name, request).Context(ctx).Do()
+	if err != nil {
+		return Key{}, nil, fmt.Errorf("error creating new service acount key for %s: %v", name, err)
+	}
+
+	keyID := extractServiceAccountKeyIdFromFullName(newKey.Name)
+	logs.Info.Printf("created new service account key %s for %s", keyID, serviceAccountEmail)
+
+	jsonData, err := base64.StdEncoding.DecodeString(newKey.PrivateKeyData)
+	if err != nil {
+		return Key{}, nil, fmt.Errorf("error decoding private key data for new service account key %s for %s: %v", keyID, serviceAccountEmail, err)
+	}
+
+	return Key{
+		Project:             project,
+		ServiceAccountEmail: serviceAccountEmail,
+		ID:                  keyID,
+	}, jsonData, nil
+}
+
+func (k *keyops) IsDisabled(key Key) (bool, error) {
+	resp, err := k.iam.Projects.ServiceAccounts.Keys.Get(key.qualifiedKeyName()).Context(context.Background()).Do()
+	if err != nil {
+		return false, fmt.Errorf("api request for %s failed: %v", key.qualifiedKeyName(), err)
+	}
+
+	return resp.Disabled, nil
+}
+
+func (k *keyops) EnsureDisabled(key Key) error {
+	disabled, err := k.IsDisabled(key)
+	if err != nil {
+		return err
+	}
+	if disabled {
+		logs.Info.Printf("won't disable %s; key is already disabled", key.qualifiedKeyName())
+		return nil
+	}
+
+	logs.Info.Printf("disabling %s", key.qualifiedKeyName())
+	request := &iam.DisableServiceAccountKeyRequest{}
+	_, err = k.iam.Projects.ServiceAccounts.Keys.Disable(key.qualifiedKeyName(), request).Context(context.Background()).Do()
+	if err != nil {
+		return fmt.Errorf("api request to disable %s failed: %v", key.qualifiedKeyName(), err)
+	}
+	return nil
+}
+
+func (k *keyops) Delete(key Key) error {
+	logs.Info.Printf("deleting %s", key.qualifiedKeyName())
+	_, err := k.iam.Projects.ServiceAccounts.Keys.Delete(key.qualifiedKeyName()).Context(context.Background()).Do()
+	return err
+}
+
+// return qualified key name for use in IAM api calls.
+// eg. "projects/my-project/serviceAccounts/my-service-account@my-project/keys/123"
+func (k Key) qualifiedKeyName() string {
+	return qualifiedKeyName(k.Project, k.ServiceAccountEmail, k.ID)
+}
+
+// return qualified key name for use in IAM api calls.
+// eg. "projects/my-project/serviceAccounts/my-service-account@my-project/keys/123"
+func qualifiedKeyName(project string, email string, keyID string) string {
+	prefix := qualifiedServiceAccountName(project, email)
+	return fmt.Sprintf("%s/keys/%s", prefix, keyID)
+}
+
+// return qualified service account name for use in IAM api calls.
+// eg. "projects/my-project/serviceAccounts/my-service-account@my-project"
+func qualifiedServiceAccountName(project string, email string) string {
+	return fmt.Sprintf("projects/%s/serviceAccounts/%s", project, email)
+}
+
+// "projects/broad-dsde-qa/serviceAccounts/whoever@gserviceaccount.com/keys/abcdef0123"
+// ->
+// "abcdef0123"
+func extractServiceAccountKeyIdFromFullName(name string) string {
+	tokens := strings.SplitN(name, "/keys/", 2)
+	if len(tokens) != 2 {
+		return ""
+	}
+	return tokens[1]
+}

--- a/internal/yale/keyops/keyops_test.go
+++ b/internal/yale/keyops/keyops_test.go
@@ -1,0 +1,97 @@
+package keyops
+
+import (
+	"encoding/base64"
+	mockiam "github.com/broadinstitute/yale/internal/yale/keyops/testutils/iam"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iam/v1"
+	"testing"
+)
+
+const testProject = "my-project"
+const testServiceAccount = "my-sa@my-project.iam.gserviceaccount.com"
+const testKeyId = "my-key-id"
+
+func Test_KeyCreate(t *testing.T) {
+	ko := setup(t, func(expect mockiam.Expect) {
+		expect.CreateServiceAccountKey(testProject, testServiceAccount).
+			With(
+				iam.CreateServiceAccountKeyRequest{
+					KeyAlgorithm:   KEY_ALGORITHM,
+					PrivateKeyType: KEY_FORMAT,
+				},
+			).Returns(
+			iam.ServiceAccountKey{
+				Name:           qualifiedKeyName(testProject, testServiceAccount, testKeyId),
+				PrivateKeyData: base64.StdEncoding.EncodeToString([]byte(`{"foo":"bar"}`)),
+			},
+		)
+	})
+
+	key, data, err := ko.Create(testProject, testServiceAccount)
+	require.NoError(t, err)
+
+	assert.Equal(t, testProject, key.Project)
+	assert.Equal(t, testServiceAccount, key.ServiceAccountEmail)
+	assert.Equal(t, testKeyId, key.ID)
+	assert.Equal(t, `{"foo":"bar"}`, string(data))
+}
+
+func Test_EnsureDisabledDisablesKeyIfEnabled(t *testing.T) {
+	ko := setup(t, func(expect mockiam.Expect) {
+		expect.GetServiceAccountKey(testProject, testServiceAccount, testKeyId).Returns(iam.ServiceAccountKey{
+			Name:     qualifiedKeyName(testProject, testServiceAccount, testKeyId),
+			Disabled: false,
+		})
+		expect.DisableServiceAccountKey(testProject, testServiceAccount, testKeyId).
+			With(iam.DisableServiceAccountKeyRequest{}).Returns()
+	})
+
+	err := ko.EnsureDisabled(Key{
+		Project:             testProject,
+		ServiceAccountEmail: testServiceAccount,
+		ID:                  testKeyId,
+	})
+
+	assert.NoError(t, err)
+}
+
+func Test_EnsureDisabledDoesNotDisableKeyIfAlreadyDisabled(t *testing.T) {
+	ko := setup(t, func(expect mockiam.Expect) {
+		expect.GetServiceAccountKey(testProject, testServiceAccount, testKeyId).Returns(iam.ServiceAccountKey{
+			Name:     qualifiedKeyName(testProject, testServiceAccount, testKeyId),
+			Disabled: true,
+		})
+	})
+	err := ko.EnsureDisabled(Key{
+		Project:             testProject,
+		ServiceAccountEmail: testServiceAccount,
+		ID:                  testKeyId,
+	})
+	assert.NoError(t, err)
+}
+
+func Test_Delete(t *testing.T) {
+	ko := setup(t, func(expect mockiam.Expect) {
+		expect.DeleteServiceAccountKey(testProject, testServiceAccount, testKeyId).Returns()
+	})
+	err := ko.Delete(Key{
+		Project:             testProject,
+		ServiceAccountEmail: testServiceAccount,
+		ID:                  testKeyId,
+	})
+	assert.NoError(t, err)
+}
+
+func setup(t *testing.T, expectFn func(mockiam.Expect)) Keyops {
+	mockIam := mockiam.NewMockIAMService(expectFn)
+
+	mockIam.Setup()
+	t.Cleanup(func() {
+		mockIam.AssertExpectations(t)
+		mockIam.Cleanup()
+	})
+
+	return New(mockIam.GetClient())
+}

--- a/internal/yale/keyops/testutils/iam/expect.go
+++ b/internal/yale/keyops/testutils/iam/expect.go
@@ -1,0 +1,69 @@
+package gcp
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const gcpIamURL = "https://iam.googleapis.com/v1"
+
+// Expect is an interface for setting expectations on a mock iam.Service
+type Expect interface {
+	// CreateServiceAccountKey configures the mock to expect a request to create a service account key
+	CreateServiceAccountKey(project string, serviceAccountEmail string) CreateServiceAccountKeyRequest
+	// GetServiceAccountKey configures the mock to expect a request to get a service account key
+	GetServiceAccountKey(project string, serviceAccountEmail string, keyId string) GetServiceAccountKeyRequest
+	// DisableServiceAccountKey configures the mock to expect a request to disable a service account key
+	DisableServiceAccountKey(project string, serviceAccountEmail string, keyId string) DisableServiceAccountKeyRequest
+	// DeleteServiceAccountKey configures the mock to expect a request that deletes a service account key
+	DeleteServiceAccountKey(project string, serviceAccountEmail string, keyId string) DeleteServiceAccountKeyRequest
+}
+
+func newExpect() *expect {
+	return &expect{}
+}
+
+// implements the Expect interface
+type expect struct {
+	requests []Request
+}
+
+// CreateServiceAccountKey
+// see https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/create
+func (e *expect) CreateServiceAccountKey(project string, serviceAccountEmail string) CreateServiceAccountKeyRequest {
+	url := fmt.Sprintf("%s/projects/%s/serviceAccounts/%s/keys", gcpIamURL, project, serviceAccountEmail)
+	r := newCreateServiceAccountKeyRequest(methodPost, url)
+	e.addNewRequest(r)
+	return r
+}
+
+// GetServiceAccountKey
+// see https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/get
+func (e *expect) GetServiceAccountKey(project string, serviceAccountEmail string, keyId string) GetServiceAccountKeyRequest {
+	url := fmt.Sprintf("%s/projects/%s/serviceAccounts/%s/keys/%s", gcpIamURL, project, serviceAccountEmail, keyId)
+	r := newGetServiceAccountKeyRequest(methodGet, url)
+	e.addNewRequest(r)
+	return r
+}
+
+// DisableServiceAccountKey
+// see https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/disable
+func (e *expect) DisableServiceAccountKey(project string, serviceAccountEmail string, keyId string) DisableServiceAccountKeyRequest {
+	url := fmt.Sprintf("%s/projects/%s/serviceAccounts/%s/keys/%s:disable", gcpIamURL, project, serviceAccountEmail, keyId)
+	r := newDisableServiceAccountKeyRequest(methodPost, url)
+	e.addNewRequest(r)
+	return r
+}
+
+// DeleteServiceAccountKey
+// see https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/delete
+func (e *expect) DeleteServiceAccountKey(project string, serviceAccountEmail string, keyId string) DeleteServiceAccountKeyRequest {
+	url := fmt.Sprintf("%s/projects/%s/serviceAccounts/%s/keys/%s", gcpIamURL, project, serviceAccountEmail, keyId)
+	r := newDeleteServiceAccountKeyRequest(http.MethodDelete, url)
+	e.addNewRequest(r)
+	return r
+}
+
+func (e *expect) addNewRequest(r Request) {
+	e.requests = append(e.requests, r)
+}

--- a/internal/yale/keyops/testutils/iam/mock.go
+++ b/internal/yale/keyops/testutils/iam/mock.go
@@ -1,0 +1,80 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+	"net/http"
+	"testing"
+)
+
+type Mock interface {
+	// Setup enables httpmock
+	Setup()
+	// Verify verifies that all expectations on the mock client were met
+	AssertExpectations(t *testing.T) bool
+	// Cleanup disables httpmock
+	Cleanup()
+}
+
+func NewMockIAMService(expectFn func(expect Expect)) *iamMock {
+	e := newExpect()
+	expectFn(e)
+
+	httpClient := &http.Client{}
+	iamClient, err := iam.NewService(context.Background(), option.WithoutAuthentication(), option.WithHTTPClient(httpClient))
+	if err != nil {
+		panic(err)
+	}
+
+	return &iamMock{
+		requests:   e.requests,
+		httpClient: httpClient,
+		iamClient:  iamClient,
+	}
+}
+
+type iamMock struct {
+	requests   []Request
+	httpClient *http.Client
+	iamClient  *iam.Service
+}
+
+func (m *iamMock) Setup() {
+	httpmock.ActivateNonDefault(m.httpClient)
+	m.registerResponders()
+}
+
+func (m *iamMock) GetClient() *iam.Service {
+	return m.iamClient
+}
+
+func (m *iamMock) AssertExpectations(t *testing.T) bool {
+	return assert.NoError(t, m.verifyCallCounts())
+}
+
+func (m *iamMock) Cleanup() {
+	httpmock.DeactivateAndReset()
+}
+
+// registerResponders configures httpmock to respond to mocked requests
+func (m *iamMock) registerResponders() {
+	for _, r := range m.requests {
+		httpmock.RegisterResponder(r.getMethod(), r.getUrl(), r.buildResponder())
+	}
+}
+
+// verifyCallCounts verifies all mocked HTTP requests were made
+func (m *iamMock) verifyCallCounts() error {
+	counts := httpmock.GetCallCountInfo()
+	for _, r := range m.requests {
+		key := fmt.Sprintf("%s %s", r.getMethod(), r.getUrl())
+		if counts[key] != r.getCallCount() {
+			return fmt.Errorf("%s: %d calls expected, %d received", key, r.getCallCount(), counts[key])
+		}
+	}
+	return nil
+}

--- a/internal/yale/keyops/testutils/iam/request.go
+++ b/internal/yale/keyops/testutils/iam/request.go
@@ -1,0 +1,185 @@
+package gcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jarcoal/httpmock"
+	"github.com/pkg/errors"
+	"google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+)
+
+const methodGet = "GET"
+const methodPost = "POST"
+
+const defaultGetStatus = 200
+const defaultPostStatus = 201
+
+// Request encapsulates a mocked GCP API request & response
+type Request interface {
+	// RequestBody requires that any requests matching the url pattern have the given response body (marshalled to JSON)
+	RequestBody(requestBody interface{}) Request
+	// Status sets status for the mock response (default 200 for requests without a body, 201 for requests with a body)
+	Status(status int)
+	// CallCount sets the expected about of calls for the mocked request (
+	CallCount(callcount int)
+	// CallCount sets the expected about of calls for the mocked request (
+	Error(error *googleapi.Error)
+	// ResponseBody sets the body for the mock response (marshalled to JSON)
+	ResponseBody(responseBody interface{}) Request
+	// Times sets the number of times this request should be expected
+	Times(callCount int) Request
+	// getMethod returns the method
+	getMethod() string
+	// getUrl returns the url
+	getUrl() string
+	// getCallCount returns the call count
+	getCallCount() int
+	// buildResponder returns an httpmock.Responder for this request
+	buildResponder() httpmock.Responder
+}
+
+// request implements Request interface
+type request struct {
+	method       string
+	url          string
+	requestBody  interface{}
+	error        *googleapi.Error
+	status       int
+	responseBody interface{}
+	callCount    int
+}
+
+func (r *request) Error(error *googleapi.Error) {
+	r.error = error
+}
+
+func (r *request) CallCount(callcount int) {
+	r.callCount = callcount
+}
+
+func newRequest(method string, url string) *request {
+	return &request{
+		method:    method,
+		url:       url,
+		callCount: 1,
+	}
+}
+
+// RequestBody verifies that the request has the given request body (marshalled to JSON)
+func (r *request) RequestBody(requestBody interface{}) Request {
+	r.requestBody = requestBody
+	return r
+}
+
+// Status sets status for the mock response (default 200 for requests without a body, 201 for requests with a body)
+func (r *request) Status(status int) {
+	r.status = status
+}
+
+// ResponseBody sets the body for the mock response (marshalled to JSON)
+func (r *request) ResponseBody(responseBody interface{}) Request {
+
+	r.responseBody = responseBody
+	return r
+}
+
+// Times sets the number of times this request should be expected
+func (r *request) Times(callCount int) Request {
+	r.callCount = callCount
+	return r
+}
+
+func (r *request) buildResponder() httpmock.Responder {
+	switch r.method {
+	case methodPost:
+		return buildPostResponder(r)
+
+	default:
+		return buildResponder(r)
+	}
+}
+
+// Creates a simple responder for requests
+func buildResponder(r *request) httpmock.Responder {
+	status := r.status
+	if status == 0 {
+		status = defaultGetStatus
+	}
+	//if status != defaultGetStatus {
+	//	return buildErrorResponder(r)
+	//}
+	return func(req *http.Request) (*http.Response, error) {
+
+		return httpmock.NewJsonResponse(status, r.responseBody)
+	}
+
+}
+
+// Creates an httpmock.Responder for POST requests that validates the actual request body matches the expected request body
+func buildPostResponder(r *request) httpmock.Responder {
+	if r.method != methodPost {
+		panic("this function should only be called for post requests")
+	}
+	status := r.status
+	if status == 0 {
+		status = defaultPostStatus
+	}
+
+	if r.responseBody == nil {
+		panic(fmt.Errorf("please configure a response body for %v %v", r.method, r.url))
+	}
+
+	return func(req *http.Request) (*http.Response, error) {
+		// We need to compare the _expected_ request body with the _actual_ request body,
+		// to make sure we're sending the right API calls to GCP.
+		//
+		// Since the _actual_ request body is passed to us as a JSON string, but callers of this method
+		// should pass in the _expected_ request body as a GCP client struct like
+		// `compute.RegionDisksAddResourcePoliciesRequest`, we convert both to map[string]interface{} and compare
+		// then with cmp.diff(). To do this, we marshal the expected struct to JSON and then unmarshal it back to
+		// map[string]interface{}.
+		//
+		// A Go expert might be able to do something fancier with reflection, in the mean time this gets the job done :)
+		var expected, actual map[string]interface{}
+
+		expectedBytes, err := json.Marshal(r.requestBody)
+		if err != nil {
+			return nil, err
+		}
+		if err = json.Unmarshal(expectedBytes, &expected); err != nil {
+			return nil, err
+		}
+
+		actualBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err = json.Unmarshal(actualBytes, &actual); err != nil {
+			return nil, err
+		}
+
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			return nil, fmt.Errorf("POST %s\n\t%T differ (-got, +want):\n%s", r.url, r.requestBody, diff)
+		}
+		if status != defaultPostStatus {
+			return nil, errors.New("The request has thrown an error.")
+		}
+
+		return httpmock.NewJsonResponse(status, r.responseBody)
+	}
+}
+
+func (r *request) getMethod() string {
+	return r.method
+}
+
+func (r *request) getUrl() string {
+	return r.url
+}
+
+func (r *request) getCallCount() int {
+	return r.callCount
+}

--- a/internal/yale/keyops/testutils/iam/requests.go
+++ b/internal/yale/keyops/testutils/iam/requests.go
@@ -1,0 +1,105 @@
+package gcp
+
+import (
+	"google.golang.org/api/iam/v1"
+)
+
+// create key
+type CreateServiceAccountKeyRequest interface {
+	With(keyRequest iam.CreateServiceAccountKeyRequest) CreateServiceAccountKeyRequest
+	Returns(key iam.ServiceAccountKey) CreateServiceAccountKeyRequest
+	Request
+}
+
+type createServiceAccountKeyRequest struct {
+	request
+}
+
+func newCreateServiceAccountKeyRequest(method string, url string) CreateServiceAccountKeyRequest {
+	return &createServiceAccountKeyRequest{
+		request: *newRequest(method, url),
+	}
+}
+
+func (r *createServiceAccountKeyRequest) With(keyRequest iam.CreateServiceAccountKeyRequest) CreateServiceAccountKeyRequest {
+	r.RequestBody(keyRequest)
+	return r
+}
+
+func (r *createServiceAccountKeyRequest) Returns(key iam.ServiceAccountKey) CreateServiceAccountKeyRequest {
+	r.ResponseBody(key)
+	return r
+}
+
+// get key
+type GetServiceAccountKeyRequest interface {
+	Returns(key iam.ServiceAccountKey) GetServiceAccountKeyRequest
+	Request
+}
+
+type getServiceAccountKeyRequest struct {
+	request
+}
+
+func newGetServiceAccountKeyRequest(method string, url string) GetServiceAccountKeyRequest {
+	return &getServiceAccountKeyRequest{
+		request: *newRequest(method, url),
+	}
+}
+
+func (r *getServiceAccountKeyRequest) Returns(key iam.ServiceAccountKey) GetServiceAccountKeyRequest {
+	r.ResponseBody(key)
+	return r
+}
+
+// Disable key
+type DisableServiceAccountKeyRequest interface {
+	With(keyRequest iam.DisableServiceAccountKeyRequest) DisableServiceAccountKeyRequest
+	Returns() DisableServiceAccountKeyRequest
+	Request
+}
+
+type disableServiceAccountKeyRequest struct {
+	request
+}
+
+func (r *disableServiceAccountKeyRequest) With(keyRequest iam.DisableServiceAccountKeyRequest) DisableServiceAccountKeyRequest {
+	r.RequestBody(keyRequest)
+	return r
+}
+
+// https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/disable#response-bodyhttps://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/disable#response-body
+func (r *disableServiceAccountKeyRequest) Returns() DisableServiceAccountKeyRequest {
+	r.ResponseBody(struct {
+	}{})
+	return r
+}
+
+func newDisableServiceAccountKeyRequest(method string, url string) DisableServiceAccountKeyRequest {
+	return &disableServiceAccountKeyRequest{
+		request: *newRequest(method, url),
+	}
+}
+
+// Delete key
+type DeleteServiceAccountKeyRequest interface {
+	Returns() DeleteServiceAccountKeyRequest
+	Request
+}
+
+type deleteServiceAccountKeyRequest struct {
+	request
+}
+
+func newDeleteServiceAccountKeyRequest(method string, url string) DeleteServiceAccountKeyRequest {
+	return &deleteServiceAccountKeyRequest{
+		request: *newRequest(method, url),
+	}
+}
+
+// https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/disable#response-bodyhttps://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/disable#response-body
+func (r *deleteServiceAccountKeyRequest) Returns() DeleteServiceAccountKeyRequest {
+	r.ResponseBody(struct {
+	}{})
+	return r
+}


### PR DESCRIPTION
This PR contains miscellaneous library changes that have come up while integrating the cache read features into Yale.

### Changes

* `keyops`: Wrap key create/disable/delete api calls in a separate package that can be mocked for easy testing; re-use Yale's existing mocking code to mock API calls
* `authmetrics`: fix package name typo
* `cutoff`: Add a fixed-time 3-day window for determining if it's safe to disable a given key. (this came up while integrating authmetrics into Yale's code)

### Testing

Added unit test coverage for new code.

### Risk: Low

Yale's `main` does not use these packages yet; those changes will be integrated in a separate PR.