### PR TITLE
[DDO-2801] Factor key sync code out into a separate library with unit tests

### DIFF
--- a/internal/yale/cache.go
+++ b/internal/yale/cache.go
@@ -65,6 +65,7 @@ func (m *Yale) PopulateCache() error {
 
 		cacheEntry.RotatedKeys = make(map[string]time.Time)
 		cacheEntry.DisabledKeys = make(map[string]time.Time)
+		cacheEntry.SyncStatus = make(map[string]string)
 
 		oldKeyName := secret.Annotations[oldServiceAccountKeyNameAnnotation]
 		if oldKeyName != "" {

--- a/internal/yale/cutoff/cutoff.go
+++ b/internal/yale/cutoff/cutoff.go
@@ -28,6 +28,7 @@ const oneDay = 24 * time.Hour
 // lastAuthSafeDisableBuffer consider a key safe to disable if it has not been used within this much time
 const lastAuthSafeDisableBuffer = 3 * oneDay
 
+// Cutoffs is responsible for determining when a service account key should be rotated, disabled, or deleted
 type Cutoffs interface {
 	// ShouldRotate Return true if the key created at the given timestamp should be rotated
 	ShouldRotate(createdAt time.Time) bool

--- a/internal/yale/keyops/keyops.go
+++ b/internal/yale/keyops/keyops.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 )
 
-// KEY_ALGORITHM what key algorithm to use when creating new Google SA keys
-const KEY_ALGORITHM string = "KEY_ALG_RSA_2048"
+// keyAlgorithm what key algorithm to use when creating new Google SA keys
+const keyAlgorithm string = "KEY_ALG_RSA_2048"
 
-// KEY_FORMAT format to use when creating new Google SA keys
-const KEY_FORMAT string = "TYPE_GOOGLE_CREDENTIALS_FILE"
+// keyFormat format to use when creating new Google SA keys
+const keyFormat string = "TYPE_GOOGLE_CREDENTIALS_FILE"
 
 // Key represents a Google IAM service account key
 type Key struct {
@@ -53,8 +53,8 @@ func (k *keyops) Create(project string, serviceAccountEmail string) (Key, []byte
 	name := qualifiedServiceAccountName(project, serviceAccountEmail)
 	ctx := context.Background()
 	request := &iam.CreateServiceAccountKeyRequest{
-		KeyAlgorithm:   KEY_ALGORITHM,
-		PrivateKeyType: KEY_FORMAT,
+		KeyAlgorithm:   keyAlgorithm,
+		PrivateKeyType: keyFormat,
 	}
 
 	logs.Info.Printf("creating new service account for %s...", serviceAccountEmail)

--- a/internal/yale/keyops/keyops_test.go
+++ b/internal/yale/keyops/keyops_test.go
@@ -18,8 +18,8 @@ func Test_KeyCreate(t *testing.T) {
 		expect.CreateServiceAccountKey(testProject, testServiceAccount).
 			With(
 				iam.CreateServiceAccountKeyRequest{
-					KeyAlgorithm:   KEY_ALGORITHM,
-					PrivateKeyType: KEY_FORMAT,
+					KeyAlgorithm:   keyAlgorithm,
+					PrivateKeyType: keyFormat,
 				},
 			).Returns(
 			iam.ServiceAccountKey{

--- a/internal/yale/keysync/keysync.go
+++ b/internal/yale/keysync/keysync.go
@@ -1,0 +1,215 @@
+package keysync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/broadinstitute/yale/internal/yale/cache"
+	apiv1b1 "github.com/broadinstitute/yale/internal/yale/crd/api/v1beta1"
+	"github.com/broadinstitute/yale/internal/yale/logs"
+	vaultapi "github.com/hashicorp/vault/api"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const defaultVaultReplicationSecretKey = "sa-key"
+
+// KeySync is responsible for propagating the current service account key from the Yale cache to destinations
+// specified in the GcpSaKey spec - Vault paths, Kubernetes secrets, etc.
+type KeySync interface {
+	// SyncIfNeeded for every given gsk, sync the current service account key in the cache entry to
+	// the Kubernetes secret and Vault paths that are specified in the gsk's spec.
+	//
+	// Note that this function will update the cache entry's SyncStatus map to reflect any sync's it performs,
+	// but it WILL NOT save the entry to the cache -- that's the caller's responsibility!
+	SyncIfNeeded(entry *cache.Entry, gsks ...apiv1b1.GCPSaKey) error
+}
+
+func New(k8s kubernetes.Interface, vault *vaultapi.Client) KeySync {
+	return &keysync{
+		k8s:   k8s,
+		vault: vault,
+	}
+}
+
+type keysync struct {
+	vault *vaultapi.Client
+	k8s   kubernetes.Interface
+}
+
+func (k *keysync) SyncIfNeeded(entry *cache.Entry, gsks ...apiv1b1.GCPSaKey) error {
+	for _, gsk := range gsks {
+		mapKey := gsk.Namespace + "/" + gsk.Name
+		data, err := json.Marshal(gsk.Spec)
+		if err != nil {
+			return fmt.Errorf("gsk %s in %s: error marshalling gsk spec to JSON: %v", gsk.Name, gsk.Namespace, err)
+		}
+		checksum, err := sha256Sum(data)
+		if err != nil {
+			return fmt.Errorf("gsk %s in %s: error computing sha265sum for gsk spec: %v", gsk.Name, gsk.Namespace, err)
+		}
+		expected := checksum + ":" + entry.CurrentKey.ID
+		actual := entry.SyncStatus[mapKey]
+
+		logs.Info.Printf("gsk %s in %s: sync status should be %q, is %q", gsk.Name, gsk.Namespace, expected, actual)
+		if actual == expected {
+			continue
+		}
+		logs.Info.Printf("gsk %s in %s: starting key sync", gsk.Name, gsk.Namespace)
+		if err = k.syncToK8sSecret(entry, gsk); err != nil {
+			return fmt.Errorf("gsk %s in %s: error syncing to K8s secret: %v", gsk.Name, gsk.Namespace, err)
+		}
+		if err = k.replicateKeyToVault(entry, gsk); err != nil {
+			return fmt.Errorf("gsk %s in %s: error syncing to Vault: %v", gsk.Name, gsk.Namespace, err)
+		}
+		entry.SyncStatus[mapKey] = expected
+	}
+
+	return nil
+}
+
+func (k *keysync) syncToK8sSecret(entry *cache.Entry, gsk apiv1b1.GCPSaKey) error {
+	namespace := gsk.Namespace
+
+	secret, err := k.k8s.CoreV1().Secrets(namespace).Get(context.Background(), gsk.Spec.Secret.Name, metav1.GetOptions{})
+	var create bool
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create ownership reference
+			// https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents
+			var ownerRef = []metav1.OwnerReference{
+				{
+					APIVersion: gsk.APIVersion,
+					Kind:       gsk.Kind,
+					Name:       gsk.Name,
+					UID:        gsk.UID,
+				},
+			}
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       gsk.Namespace,
+					Name:            gsk.Spec.Secret.Name,
+					OwnerReferences: ownerRef,
+				},
+				Type: corev1.SecretTypeOpaque,
+			}
+			create = true
+		} else {
+			return fmt.Errorf("gsk %s in %s: error retrieving referenced secret %s: %v", gsk.Name, gsk.Namespace, gsk.Spec.Secret.Name, err)
+		}
+	}
+
+	// add labels and annotations to the secret if they aren't already there
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	for k, v := range gsk.Labels {
+		secret.Labels[k] = v
+	}
+
+	// make sure reloader annotations are added to the secret
+	if secret.Annotations == nil {
+		secret.Annotations = make(map[string]string)
+	}
+	secret.Annotations["reloader.stakater.com/match"] = "true"
+
+	// extract pem-formatted key from the service account key JSON
+	pemFormatted, err := extractPemKey(entry)
+	if err != nil {
+		return fmt.Errorf("gsk %s in %s: error extracting PEM-formatted key for %s: %v", gsk.Name, gsk.Namespace, entry.ServiceAccount.Email, err)
+	}
+
+	// add the key data to the secret
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data[gsk.Spec.Secret.JsonKeyName] = []byte(entry.CurrentKey.JSON)
+	secret.Data[gsk.Spec.Secret.PemKeyName] = []byte(pemFormatted)
+
+	if create {
+		_, err = k.k8s.CoreV1().Secrets(gsk.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	} else {
+		_, err = k.k8s.CoreV1().Secrets(gsk.Namespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+	}
+	return err
+}
+
+func (k *keysync) replicateKeyToVault(entry *cache.Entry, gsk apiv1b1.GCPSaKey) error {
+	for _, spec := range gsk.Spec.VaultReplications {
+		msg := fmt.Sprintf("replicating key %s for %s to Vault (format %s, path %s, key %s)",
+			entry.CurrentKey.ID, entry.ServiceAccount.Email, spec.Format, spec.Path, spec.Key)
+		logs.Info.Print(msg)
+		secretData, err := prepareVaultSecret(entry, spec)
+		if err != nil {
+			return fmt.Errorf("error %s: decoding failed: %v", msg, err)
+		}
+
+		if _, err = k.vault.Logical().Write(spec.Path, secretData); err != nil {
+			return fmt.Errorf("error %s: write failed: %v", msg, err)
+		}
+	}
+	return nil
+}
+
+func prepareVaultSecret(entry *cache.Entry, spec apiv1b1.VaultReplication) (map[string]interface{}, error) {
+	asJson := []byte(entry.CurrentKey.JSON)
+	base64Encoded := base64.StdEncoding.EncodeToString(asJson)
+
+	asPem, err := extractPemKey(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := make(map[string]interface{})
+	secretKey := spec.Key
+	if secretKey == "" {
+		secretKey = defaultVaultReplicationSecretKey
+	}
+
+	switch spec.Format {
+	case apiv1b1.Map:
+		if err := json.Unmarshal(asJson, &secret); err != nil {
+			return nil, fmt.Errorf("error decoding private key to secret map: %v", err)
+		}
+	case apiv1b1.JSON:
+		secret[secretKey] = string(asJson)
+	case apiv1b1.Base64:
+		secret[secretKey] = base64Encoded
+	case apiv1b1.PEM:
+		secret[secretKey] = asPem
+	default:
+		panic(fmt.Errorf("unsupported Vault replication format: %#v", spec.Format))
+	}
+
+	return secret, nil
+}
+
+// compute a sha256 checksum and return in hex string form, eg.
+// "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+func sha256Sum(data []byte) (string, error) {
+	hash := sha256.New()
+	if _, err := hash.Write(data); err != nil {
+		return "", fmt.Errorf("error computing checksum: %v", err)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+// return the PEM-formatted private_key field from a cache entry's JSON-formatted SA key
+func extractPemKey(entry *cache.Entry) (string, error) {
+	asJson := []byte(entry.CurrentKey.JSON)
+
+	type keyJson struct {
+		PrivateKey string `json:"private_key"`
+	}
+	var k keyJson
+	if err := json.Unmarshal(asJson, &k); err != nil {
+		return "", fmt.Errorf("failed to decode key %s (%s) from JSON: %v", entry.CurrentKey.ID, entry.ServiceAccount.Email, err)
+	}
+	return k.PrivateKey, nil
+}

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -291,10 +291,6 @@ func (suite *KeySyncSuite) createSecret(secret *corev1.Secret) {
 	require.NoError(suite.T(), err)
 }
 
-func (suite *KeySyncSuite) deleteSecret(namespace string, name string) {
-	require.NoError(suite.T(), suite.k8s.CoreV1().Secrets(namespace).Delete(context.Background(), name, metav1.DeleteOptions{}))
-}
-
 func (suite *KeySyncSuite) assertK8sSecreDoesNotExist(namespace string, name string) {
 	_, err := suite.k8s.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	assert.Error(suite.T(), err)

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -1,0 +1,302 @@
+package keysync
+
+import (
+	"context"
+	"github.com/broadinstitute/yale/internal/yale/cache"
+	apiv1b1 "github.com/broadinstitute/yale/internal/yale/crd/api/v1beta1"
+	vaultutils "github.com/broadinstitute/yale/internal/yale/keysync/testutils/vault"
+	"github.com/broadinstitute/yale/internal/yale/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"testing"
+)
+
+type fakeKey struct {
+	id     string
+	email  string
+	json   string
+	pem    string
+	base64 string
+}
+
+var key1 = fakeKey{
+	id:     "my-key-id",
+	email:  "my-sa@my-project.com",
+	json:   `{"email":"my-sa@my-project.com","private_key":"foobar"}`,
+	pem:    "foobar",
+	base64: "eyJlbWFpbCI6Im15LXNhQG15LXByb2plY3QuY29tIiwicHJpdmF0ZV9rZXkiOiJmb29iYXIifQ==",
+}
+
+type KeySyncSuite struct {
+	suite.Suite
+	k8s         kubernetes.Interface
+	vaultServer *vaultutils.FakeVaultServer
+	keysync     KeySync
+}
+
+func TestKeySyncSuite(t *testing.T) {
+	suite.Run(t, new(KeySyncSuite))
+}
+
+func (suite *KeySyncSuite) SetupTest() {
+	suite.k8s = testutils.NewFakeK8sClient(suite.T())
+	suite.vaultServer = vaultutils.NewFakeVaultServer(suite.T())
+	suite.keysync = New(suite.k8s, suite.vaultServer.NewClient())
+}
+
+func (suite *KeySyncSuite) Test_KeySync_CreatesK8sSecret() {
+	entry := &cache.Entry{}
+	entry.CurrentKey.JSON = key1.json
+	entry.CurrentKey.ID = key1.id
+	entry.SyncStatus = map[string]string{} // no prior syncs recorded in the map
+
+	gsk := apiv1b1.GCPSaKey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gsk",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+			},
+		},
+		Spec: apiv1b1.GCPSaKeySpec{
+			Secret: apiv1b1.Secret{
+				Name:        "my-secret",
+				PemKeyName:  "my-key.pem",
+				JsonKeyName: "my-key.json",
+			},
+			VaultReplications: []apiv1b1.VaultReplication{},
+		},
+	}
+
+	suite.assertK8sSecreDoesNotExist("my-namespace", "my-secret")
+
+	// run a key sync
+	require.NoError(suite.T(), suite.keysync.SyncIfNeeded(entry, gsk))
+
+	secret, err := suite.getSecret("my-namespace", "my-secret")
+	require.NoError(suite.T(), err)
+
+	// make sure secret has the correct ownership reference
+	assert.Equal(suite.T(), "my-gsk", secret.OwnerReferences[0].Name)
+
+	// make sure secret inherited labels from gsk
+	assert.Equal(suite.T(), map[string]string{
+		"label1": "value1",
+		"label2": "value2",
+	}, secret.Labels)
+
+	// make sure secret has reloader annotations
+	assert.Equal(suite.T(), "true", secret.Annotations["reloader.stakater.com/match"])
+
+	// make sure secret has expected data
+	assert.Equal(suite.T(), key1.json, string(secret.Data["my-key.json"]))
+	assert.Equal(suite.T(), key1.pem, string(secret.Data["my-key.pem"]))
+
+	// make sure the cache entry was updated with correct key-sync record
+	assert.Len(suite.T(), entry.SyncStatus, 1)
+	assert.Equal(suite.T(), "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+}
+
+func (suite *KeySyncSuite) Test_KeySync_UpdatesK8sSecretIfAlreadyExists() {
+	entry := &cache.Entry{}
+	entry.CurrentKey.JSON = key1.json
+	entry.CurrentKey.ID = key1.id
+	entry.SyncStatus = map[string]string{} // no prior syncs recorded in the map
+
+	gsk := apiv1b1.GCPSaKey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gsk",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+			},
+		},
+		Spec: apiv1b1.GCPSaKeySpec{
+			Secret: apiv1b1.Secret{
+				Name:        "my-secret",
+				PemKeyName:  "my-key.pem",
+				JsonKeyName: "my-key.json",
+			},
+			VaultReplications: []apiv1b1.VaultReplication{},
+		},
+	}
+
+	suite.createSecret(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				"label1":      "this should be overwritten",
+				"extra-label": "this should be ignored",
+			},
+		},
+		Data: map[string][]byte{
+			"my-key.pem": []byte("this should be overwritten"),
+			"extra-data": []byte("this should be ignored"),
+		},
+	})
+
+	// run a key sync to create the secret once
+	require.NoError(suite.T(), suite.keysync.SyncIfNeeded(entry, gsk))
+
+	secret, err := suite.getSecret("my-namespace", "my-secret")
+	require.NoError(suite.T(), err)
+
+	// make sure secret inherited labels from gsk
+	assert.Equal(suite.T(), map[string]string{
+		"label1":      "value1",
+		"label2":      "value2",
+		"extra-label": "this should be ignored",
+	}, secret.Labels)
+
+	// make sure secret has reloader annotations
+	assert.Equal(suite.T(), "true", secret.Annotations["reloader.stakater.com/match"])
+
+	// make sure secret has expected data
+	assert.Equal(suite.T(), key1.json, string(secret.Data["my-key.json"]))
+	assert.Equal(suite.T(), key1.pem, string(secret.Data["my-key.pem"]))
+	assert.Equal(suite.T(), "this should be ignored", string(secret.Data["extra-data"]))
+
+	// make sure the cache entry was updated with correct key-sync record
+	assert.Len(suite.T(), entry.SyncStatus, 1)
+	assert.Equal(suite.T(), "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+}
+
+func (suite *KeySyncSuite) Test_KeySync_PerformsAllConfiguredVaultReplications() {
+	entry := &cache.Entry{}
+	entry.CurrentKey.JSON = key1.json
+	entry.CurrentKey.ID = key1.id
+	entry.SyncStatus = map[string]string{} // no prior syncs recorded in the map
+
+	gsk := apiv1b1.GCPSaKey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gsk",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+			},
+		},
+		Spec: apiv1b1.GCPSaKeySpec{
+			Secret: apiv1b1.Secret{
+				Name:        "my-secret",
+				PemKeyName:  "my-key.pem",
+				JsonKeyName: "my-key.json",
+			},
+			VaultReplications: []apiv1b1.VaultReplication{
+				{
+					Path:   "secret/foo/test/map",
+					Format: apiv1b1.Map,
+				},
+				{
+					Path:   "secret/foo/test/json",
+					Format: apiv1b1.JSON,
+					Key:    "key.json",
+				},
+				{
+					Path:   "secret/foo/test/base64",
+					Format: apiv1b1.Base64,
+					Key:    "key.b64",
+				},
+				{
+					Path:   "secret/foo/test/pem",
+					Format: apiv1b1.PEM,
+					Key:    "key.pem",
+				},
+			},
+		},
+	}
+
+	// run a key sync to create the K8s secret and perform the vault replications
+	require.NoError(suite.T(), suite.keysync.SyncIfNeeded(entry, gsk))
+
+	// verify K8s secret was created
+	_, err := suite.getSecret("my-namespace", "my-secret")
+	require.NoError(suite.T(), err)
+
+	// verify all the Vault replications were performed
+	suite.assertVaultServerHasSecret("secret/foo/test/map", map[string]interface{}{
+		"email":       key1.email,
+		"private_key": key1.pem,
+	})
+	suite.assertVaultServerHasSecret("secret/foo/test/json", map[string]interface{}{
+		"key.json": key1.json,
+	})
+	suite.assertVaultServerHasSecret("secret/foo/test/base64", map[string]interface{}{
+		"key.b64": key1.base64,
+	})
+	suite.assertVaultServerHasSecret("secret/foo/test/pem", map[string]interface{}{
+		"key.pem": key1.pem,
+	})
+
+	// make sure the cache entry was updated with correct key-sync record
+	assert.Len(suite.T(), entry.SyncStatus, 1)
+	assert.Equal(suite.T(), "89fee4211aee14f33a50bfd71bd47b2459560693a4548ca079a4c9d3d6b48337:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+}
+
+func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformASyncIfSyncStatusIsUpToDate() {
+	entry := &cache.Entry{}
+	entry.CurrentKey.JSON = key1.json
+	entry.CurrentKey.ID = key1.id
+
+	// pretend cache entry has already been synced for this gsk
+	entry.SyncStatus = map[string]string{
+		"my-namespace/my-gsk": "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:" + key1.id,
+	}
+
+	gsk := apiv1b1.GCPSaKey{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-gsk",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+			},
+		},
+		Spec: apiv1b1.GCPSaKeySpec{
+			Secret: apiv1b1.Secret{
+				Name:        "my-secret",
+				PemKeyName:  "my-key.pem",
+				JsonKeyName: "my-key.json",
+			},
+			VaultReplications: []apiv1b1.VaultReplication{},
+		},
+	}
+
+	// run a key sync to create the secret once
+	require.NoError(suite.T(), suite.keysync.SyncIfNeeded(entry, gsk))
+
+	// make sure the secret was not created
+	suite.assertK8sSecreDoesNotExist("my-namespace", "my-secret")
+}
+
+func (suite *KeySyncSuite) assertVaultServerHasSecret(path string, content map[string]interface{}) {
+	data := suite.vaultServer.GetSecret(path)
+	assert.Equal(suite.T(), content, data)
+}
+
+func (suite *KeySyncSuite) getSecret(namespace string, name string) (*corev1.Secret, error) {
+	return suite.k8s.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+}
+
+func (suite *KeySyncSuite) createSecret(secret *corev1.Secret) {
+	_, err := suite.k8s.CoreV1().Secrets(secret.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	require.NoError(suite.T(), err)
+}
+
+func (suite *KeySyncSuite) deleteSecret(namespace string, name string) {
+	require.NoError(suite.T(), suite.k8s.CoreV1().Secrets(namespace).Delete(context.Background(), name, metav1.DeleteOptions{}))
+}
+
+func (suite *KeySyncSuite) assertK8sSecreDoesNotExist(namespace string, name string) {
+	_, err := suite.k8s.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	assert.Error(suite.T(), err)
+	assert.True(suite.T(), errors.IsNotFound(err))
+}

--- a/internal/yale/keysync/testutils/vault/vault.go
+++ b/internal/yale/keysync/testutils/vault/vault.go
@@ -1,0 +1,225 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/broadinstitute/yale/internal/yale/logs"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const secretPrefix = "secret/"
+
+// NewFakeVaultServer returns a new fake vault server that can be used to fake vault secret lookups
+func NewFakeVaultServer(t *testing.T) *FakeVaultServer {
+	_state := &state{
+		secrets: make(map[string]map[string]interface{}),
+	}
+
+	mux := http.NewServeMux()
+
+	mux.Handle("/v1/auth/github/login", toHttpHandler(_state.handleGithubLogin))
+	mux.Handle("/v1/auth/token/lookup-self", toHttpHandler(_state.handleTokenLookup))
+	mux.Handle("/v1/secret/", toHttpHandler(_state.handleSecret))
+	mux.Handle("/", toHttpHandler(_state.handleUnmatchedRequest))
+
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	return &FakeVaultServer{
+		server: server,
+		state:  _state,
+		t:      t,
+	}
+}
+
+type FakeVaultServer struct {
+	server *httptest.Server
+	state  *state
+	t      *testing.T
+}
+
+// simplified http.Handler
+type vaultApiHandler func(r *http.Request) (*vaultapi.Secret, error)
+
+// represents state of the fake server
+type state struct {
+	secrets     map[string]map[string]interface{}
+	expectLogin struct {
+		enabled     bool
+		githubToken string
+		vaultToken  string
+	}
+}
+
+// NewClient return a new vault client configured to talk to this fake vault server instance
+func (s *FakeVaultServer) NewClient() *vaultapi.Client {
+	var cfg vaultapi.Config
+	s.ConfigureClient(&cfg)
+	client, err := vaultapi.NewClient(&cfg)
+	require.NoError(s.t, err)
+	return client
+}
+
+// ConfigureClient can be used to configure a vault client to talk to this fake vault server instance
+func (s *FakeVaultServer) ConfigureClient(clientConfig *vaultapi.Config) {
+	clientConfig.HttpClient = s.server.Client()
+	clientConfig.Address = s.server.URL
+}
+
+// Server returns the underlying httptest.Server associated with this fake vault server instance
+func (s *FakeVaultServer) Server() *httptest.Server {
+	return s.server
+}
+
+// ExpectGithubLogin configures the server to expect a github login with a specific Github token (by default any token is expected)
+func (s *FakeVaultServer) ExpectGithubLogin(githubToken string, vaultToken string) {
+	s.state.expectLogin.enabled = true
+	s.state.expectLogin.githubToken = githubToken
+	s.state.expectLogin.vaultToken = vaultToken
+}
+
+// SetSecret adds a secret to the fake server
+func (s *FakeVaultServer) SetSecret(path string, data map[string]interface{}) {
+	// remove secret/ prefix from key
+	path = strings.TrimPrefix(path, secretPrefix)
+	s.state.secrets[path] = data
+}
+
+// GetSecret retrieves a secret from the fake server's storage
+func (s *FakeVaultServer) GetSecret(path string) map[string]interface{} {
+	path = strings.TrimPrefix(path, secretPrefix)
+	return s.state.secrets[path]
+}
+
+func (s *state) handleGithubLogin(r *http.Request) (*vaultapi.Secret, error) {
+	if r.Method != http.MethodPost &&
+		r.Method != http.MethodPut {
+		return nil, fmt.Errorf("expected PUT or POST request")
+	}
+
+	var body struct {
+		Token string `json:"token"`
+	}
+
+	if err := parseJsonRequestBody(r, &body); err != nil {
+		return nil, err
+	}
+
+	if s.expectLogin.enabled {
+		if body.Token != s.expectLogin.githubToken {
+			return nil, fmt.Errorf("github token mismatch: expected %q, got %q", s.expectLogin.githubToken, body.Token)
+		}
+	}
+
+	return &vaultapi.Secret{
+		Auth: &vaultapi.SecretAuth{
+			ClientToken: s.expectLogin.vaultToken,
+		},
+	}, nil
+}
+
+func (s *state) handleTokenLookup(_ *http.Request) (*vaultapi.Secret, error) {
+	return &vaultapi.Secret{
+		Data: map[string]interface{}{
+			"accessor": "00000000-0000-0000-0000-000000000000",
+		},
+	}, nil
+}
+
+func (s *state) handleSecret(r *http.Request) (*vaultapi.Secret, error) {
+	secretPath := strings.TrimPrefix(r.URL.Path, "/v1/secret/")
+
+	if r.Method == http.MethodPost || r.Method == http.MethodPut {
+		var data map[string]interface{}
+		if err := parseJsonRequestBody(r, &data); err != nil {
+			return nil, err
+		}
+		logs.Info.Printf("setting secret %s to %v", secretPath, data)
+		s.secrets[secretPath] = data
+
+		var secret vaultapi.Secret
+		secret.Data = data
+		return &secret, nil
+	}
+
+	if r.Method == http.MethodGet {
+		data, exists := s.secrets[secretPath]
+		if !exists {
+			logs.Info.Printf("secret %s does not exist, returning 404", secretPath)
+			return nil, nil
+		}
+
+		logs.Info.Printf("returning secret %s: %v", secretPath, data)
+
+		var secret vaultapi.Secret
+		secret.Data = data
+		return &secret, nil
+	}
+
+	return nil, fmt.Errorf("invalid method for secrets api: %s", r.Method)
+}
+
+func (s *state) handleUnmatchedRequest(r *http.Request) (*vaultapi.Secret, error) {
+	panic(fmt.Errorf("no handler for request: %s %s", r.Method, r.URL.Path))
+}
+
+func writeSecretToResponseBody(secret *vaultapi.Secret, w http.ResponseWriter) {
+	body, err := json.Marshal(secret)
+	if err != nil {
+		panic(fmt.Errorf("error marshalling Vault secret to JSON (%v): %v", secret, err))
+	}
+
+	_, err = w.Write(body)
+	if err != nil {
+		panic(fmt.Errorf("error writing response body: %v", err))
+	}
+}
+
+// convert vaultApiHandler to http.Handler
+func toHttpHandler(handler vaultApiHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logs.Info.Printf("%s %s", r.Method, r.URL.Path)
+
+		secret, err := handler(r)
+
+		if err != nil {
+			logs.Info.Printf("400")
+			logs.Info.Printf("err: %v", err)
+
+			http.Error(w, fmt.Sprintf("Bad request (%s %s): %v", r.Method, r.URL.Path, err), http.StatusBadRequest)
+			return
+		}
+
+		if secret == nil {
+			logs.Info.Printf("404")
+
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		logs.Info.Printf("200")
+		logs.Info.Printf("%#v", secret)
+
+		w.WriteHeader(http.StatusOK)
+		writeSecretToResponseBody(secret, w)
+	})
+}
+
+func parseJsonRequestBody(r *http.Request, into interface{}) error {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		panic(fmt.Errorf("error reading request body: %v", err))
+	}
+
+	if err = json.Unmarshal(data, into); err != nil {
+		return fmt.Errorf("error unmarshalling request body: %v\n\n%s", err, string(data))
+	}
+
+	return nil
+}

--- a/internal/yale/testing/cache_test.go
+++ b/internal/yale/testing/cache_test.go
@@ -142,6 +142,7 @@ func TestPopulateCache(t *testing.T) {
 								"0001": createdAt,
 							},
 							DisabledKeys: map[string]time.Time{},
+							SyncStatus:   map[string]string{},
 						}),
 					},
 				})
@@ -173,6 +174,7 @@ func TestPopulateCache(t *testing.T) {
 							},
 							RotatedKeys:  map[string]time.Time{},
 							DisabledKeys: map[string]time.Time{},
+							SyncStatus:   map[string]string{},
 						}),
 					},
 				})

--- a/internal/yale/testutils/testutils.go
+++ b/internal/yale/testutils/testutils.go
@@ -1,0 +1,77 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-replayers/httpreplay"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"net/http"
+	"testing"
+)
+
+func NewRecordingHTTPClientWithADCAuth(t *testing.T, recordFile string) *http.Client {
+	// create new http recorder
+	httpRecorder, err := httpreplay.NewRecorder(recordFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := httpRecorder.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// add Google ADC auth to the http client
+	tokenSource, err := google.DefaultTokenSource(context.Background())
+	require.NoError(t, err)
+
+	httpClient := httpRecorder.Client()
+	httpClient.Transport = &oauth2.Transport{
+		Source: tokenSource,
+		Base:   httpClient.Transport,
+	}
+	return httpClient
+}
+
+func NewReplayingHTTPClient(t *testing.T, replayFile string) *http.Client {
+	httpReplayer, err := httpreplay.NewReplayer(replayFile)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := httpReplayer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	return httpReplayer.Client()
+}
+
+func NewFakeK8sClient(t *testing.T, objects ...runtime.Object) kubernetes.Interface {
+	k8s := k8sfake.NewSimpleClientset(objects...)
+	k8s.PrependReactor("create", "secrets", secretDataReactor)
+	return k8s
+}
+
+// secretDataReactor: A reactor that makes persists secret StringData updates to the fake cluster
+// yanked from: https://github.com/creydr/go-k8s-utils
+func secretDataReactor(action ktesting.Action) (bool, runtime.Object, error) {
+	secret, ok := action.(ktesting.CreateAction).GetObject().(*corev1.Secret)
+	if !ok {
+		return false, nil, fmt.Errorf("SecretDataReactor can only be applied on secrets")
+	}
+
+	if len(secret.StringData) > 0 {
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+
+		for k, v := range secret.StringData {
+			secret.Data[k] = []byte(v)
+		}
+	}
+
+	return false, nil, nil
+}


### PR DESCRIPTION
This PR refactors the Yale code that syncs secret data to Kubernetes secrets and Vault paths into a separate package with unit tests.

### Changes

For the most part, this PR tries to preserve the existing behavior of Yale syncs. However, it does implement retries for failed key syncs, by adding a new `SyncStatus` map to the cache entry.

Each entry in the map describes the last successful sync for a single GcpSaKey resource.
The entry's key is the name of the GcpSaKey, in the form `<namespace>/<name>`.
The entry's value contains:
* the checksum of the GcpSaKey's JSON-marshalled spec
* the id of the key that was synced
These are concatenated with a `:`, in the form `<checksum>:<key id>`.

Yale determines if it needs to perform a sync for a particular GcpSaKey by serializing the GcpSaKey's spec to JSON and checkumming it at runtime. If the checksum doesn't match, or the key id doesn't match (say, because the key was rotated), it performs a key sync and updates the stored value.

The advantages of this behavior are:
* If Yale fails to sync a value to Vault due to, say, a permissions issue, it will fail with an error
  and keep re-trying on every run until the sync succeeds.
* If a sync succeeds, Yale will not attempt to sync again until the GcpSaKey's spec changes (say, for example,
  if the key needs to be synced to a different path) or the key is rotated. This avoids overwhelming Vault with unnecessary write requests (or accruing a charges for unnecessary Google Secret Manager API calls).

### Tests

This PR includes unit tests.

### Risk: Low

This library is not used yet; it will be added for use in a separate PR.