### PR TITLE
[DDO-2856] Make error notification logic dumber

### DIFF
--- a/internal/yale/cache/entry.go
+++ b/internal/yale/cache/entry.go
@@ -27,11 +27,12 @@ func (sa ServiceAccount) cacheSecretName() string {
 
 // LastError information relating to the last error that occurred while processing this cache entry/service account
 type LastError struct {
-	Message         string
-	Count           int
-	FirstOccurrence time.Time
-	LastOccurrence  time.Time
-	LastReportedAt  time.Time
+	// Message is the last error message
+	Message string
+	// Timestamp is the timestamp at which the last error occurred
+	Timestamp time.Time
+	// LastNotificationAt is the timestamp at which the last error notification was sent for this cache entry
+	LastNotificationAt time.Time
 }
 
 // CurrentKey represents the current/active service account key that will

--- a/internal/yale/yale.go
+++ b/internal/yale/yale.go
@@ -362,8 +362,7 @@ func (m *Yale) reportError(entry *cache.Entry, err error) error {
 		return nil
 	}
 
-	msg := fmt.Sprintf("error processing service account %s: %s", entry.ServiceAccount.Email, entry.LastError.Message)
-	if err = m.slack.Error(entry, msg); err != nil {
+	if err = m.slack.Error(entry, entry.LastError.Message); err != nil {
 		return fmt.Errorf("error reporting error to Slack: %v", err)
 	}
 


### PR DESCRIPTION
My earlier [PR](https://github.com/broadinstitute/yale/pull/34) tried to be too cute and detect if an error for a given cache entry was "new" or not by checking if the message had changed. Unfortunately some error messages include timestamps -- the error will always be "new".

This PR updates Yale to send one error notification per service account key every four hours, regardless of whether the error is new/different or not.

### Testing

This PR includes unit tests. I will also verify the throttling works by deploying to dev before merging.