### PR TITLE
[DDO-2864] Make it possible to disable in use checking for individual SA keys

### DIFF
--- a/cmd/yale/main.go
+++ b/cmd/yale/main.go
@@ -14,10 +14,10 @@ import (
 
 type args struct {
 	// use local kube config
-	local          bool
-	kubeconfig     string
-	cacheNamespace string
-	checkInUse     bool
+	local              bool
+	kubeconfig         string
+	cacheNamespace     string
+	ignoreUsageMetrics bool
 }
 
 func main() {
@@ -31,7 +31,7 @@ func main() {
 	}
 	m := yale.NewYale(clients, func(options *yale.Options) {
 		options.CacheNamespace = args.cacheNamespace
-		options.IgnoreUsageMetrics = args.checkInUse
+		options.IgnoreUsageMetrics = args.ignoreUsageMetrics
 		options.SlackWebhookUrl = os.Getenv(slack.WebhookEnvVar)
 	})
 	if err = m.Run(); err != nil {
@@ -48,7 +48,7 @@ func parseArgs() *args {
 	}
 	local := flag.Bool("local", false, "use this flag when running locally (outside of cluster to use local kube config")
 	cacheNamespace := flag.String("cachenamespace", cache.DefaultCacheNamespace, "namespace where yale should cache service account keys")
-	checkInUse := flag.Bool("ignoreusagemetrics", false, "do not check if service account key is in use before disabling")
+	ignoreUsageMetrics := flag.Bool("ignoreusagemetrics", false, "do not check if service account key is in use before disabling")
 	flag.Parse()
-	return &args{*local, *kubeconfig, *cacheNamespace, *checkInUse}
+	return &args{*local, *kubeconfig, *cacheNamespace, *ignoreUsageMetrics}
 }

--- a/cmd/yale/main.go
+++ b/cmd/yale/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 	m := yale.NewYale(clients, func(options *yale.Options) {
 		options.CacheNamespace = args.cacheNamespace
-		options.CheckInUseBeforeDisabling = args.checkInUse
+		options.IgnoreUsageMetrics = args.checkInUse
 		options.SlackWebhookUrl = os.Getenv(slack.WebhookEnvVar)
 	})
 	if err = m.Run(); err != nil {
@@ -48,7 +48,7 @@ func parseArgs() *args {
 	}
 	local := flag.Bool("local", false, "use this flag when running locally (outside of cluster to use local kube config")
 	cacheNamespace := flag.String("cachenamespace", cache.DefaultCacheNamespace, "namespace where yale should cache service account keys")
-	checkInUse := flag.Bool("checkinuse", true, "check if service account is in use before disabling")
+	checkInUse := flag.Bool("ignoreusagemetrics", false, "do not check if service account key is in use before disabling")
 	flag.Parse()
 	return &args{*local, *kubeconfig, *cacheNamespace, *checkInUse}
 }

--- a/internal/yale/crd/api/v1beta1/types.go
+++ b/internal/yale/crd/api/v1beta1/types.go
@@ -26,9 +26,10 @@ type Secret struct {
 }
 
 type KeyRotation struct {
-	RotateAfter  int `json:"rotateAfter"`
-	DeleteAfter  int `json:"deleteAfter"`
-	DisableAfter int `json:"disableAfter"`
+	RotateAfter        int  `json:"rotateAfter"`
+	DeleteAfter        int  `json:"deleteAfter"`
+	DisableAfter       int  `json:"disableAfter"`
+	IgnoreUsageMetrics bool `json:"ignoreUsageMetrics"`
 }
 
 type VaultReplication struct {

--- a/internal/yale/cutoff/cutoff_test.go
+++ b/internal/yale/cutoff/cutoff_test.go
@@ -318,3 +318,174 @@ func Test_computeThresholds(t *testing.T) {
 		})
 	}
 }
+
+func Test_computeIgnoreUsageMetrics(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []v1beta1.GCPSaKey
+		expected bool
+	}{
+		{
+			name:     "empty",
+			input:    []v1beta1.GCPSaKey{},
+			expected: false,
+		},
+		{
+			name: "single gsk with ignoreUsageMetrics set to false",
+			input: []v1beta1.GCPSaKey{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-1",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: false,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "single gsk with ignoreUsageMetrics set to true",
+			input: []v1beta1.GCPSaKey{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-1",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: true,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple gsks with ignoreUsageMetrics set to true",
+			input: []v1beta1.GCPSaKey{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-1",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: true,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-2",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: true,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-3",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: true,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple gsks with ignoreUsageMetrics set to false",
+			input: []v1beta1.GCPSaKey{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-1",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: false,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-2",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: false,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-3",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: false,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "multiple gsks with ignoreUsageMetrics set to true and false",
+			input: []v1beta1.GCPSaKey{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-1",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: true,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-2",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: false,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gsk-3",
+						Namespace: "ns-1",
+					},
+					Spec: v1beta1.GCPSaKeySpec{
+						KeyRotation: v1beta1.KeyRotation{
+							IgnoreUsageMetrics: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, computeIgnoreUsageMetrics(tc.input))
+		})
+	}
+}

--- a/internal/yale/cutoff/cutoff_test.go
+++ b/internal/yale/cutoff/cutoff_test.go
@@ -141,6 +141,35 @@ func Test_Cutoffs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should always return safe to disable if ignore usage metrics is true",
+			input: v1beta1.KeyRotation{
+				RotateAfter:        7,
+				DisableAfter:       7,
+				DeleteAfter:        3,
+				IgnoreUsageMetrics: true,
+			},
+			expectedThresholds: thresholds{
+				rotateAfter:  7,
+				disableAfter: 7,
+				deleteAfter:  3,
+			},
+			expectedCutoffs: cutoffTimes{
+				rotateCutoff:        "2023-04-21T09:10:11Z",
+				disableCutoff:       "2023-04-21T09:10:11Z",
+				safeToDisableCutoff: "2023-04-25T09:10:11Z",
+				deleteCutoff:        "2023-04-25T09:10:11Z",
+			},
+			shouldChecks: []shouldChecks{
+				{
+					input:       "2023-04-27T00:00:00Z",
+					rotate:      false,
+					disable:     false,
+					safeDisable: true,
+					delete:      false,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -105,7 +105,7 @@ func (suite *KeySyncSuite) Test_KeySync_CreatesK8sSecret() {
 
 	// make sure the cache entry was updated with correct key-sync record
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_UpdatesK8sSecretIfAlreadyExists() {
@@ -173,7 +173,7 @@ func (suite *KeySyncSuite) Test_KeySync_UpdatesK8sSecretIfAlreadyExists() {
 
 	// make sure the cache entry was updated with correct key-sync record
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_PerformsAllConfiguredVaultReplications() {
@@ -247,7 +247,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsAllConfiguredVaultReplications()
 
 	// make sure the cache entry was updated with correct key-sync record
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "89fee4211aee14f33a50bfd71bd47b2459560693a4548ca079a4c9d3d6b48337:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "729c209216257d3d2651002acbac6131be54431d6e9914e58821187262e389f8:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_PerformsASyncIfSyncStatusIsUpToDateButSecretIsMissing() {
@@ -299,7 +299,7 @@ func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformASyncIfSyncStatusIsUpToDat
 
 	// pretend cache entry has already been synced for this gsk
 	entry.SyncStatus = map[string]string{
-		"my-namespace/my-gsk": "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:" + key1.id,
+		"my-namespace/my-gsk": "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:" + key1.id,
 	}
 
 	gsk := apiv1b1.GCPSaKey{
@@ -347,9 +347,9 @@ func (suite *KeySyncSuite) Test_KeySync_PrunesOldStatusEntries() {
 	entry.CurrentKey.JSON = key1.json
 	entry.CurrentKey.ID = key1.id
 	entry.SyncStatus = map[string]string{
-		"my-namespace/my-gsk":         "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:" + key1.id, // should not be deleted
-		"my-namespace/deleted-gsk":    "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:" + key1.id, // should be deleted
-		"other-namespace/deleted-gsk": "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:" + key1.id, // should be deleted
+		"my-namespace/my-gsk":         "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:" + key1.id, // should not be deleted
+		"my-namespace/deleted-gsk":    "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:" + key1.id, // should be deleted
+		"other-namespace/deleted-gsk": "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:" + key1.id, // should be deleted
 	}
 
 	gsk := apiv1b1.GCPSaKey{
@@ -374,7 +374,7 @@ func (suite *KeySyncSuite) Test_KeySync_PrunesOldStatusEntries() {
 
 	// make sure the cache entry's sync status map has exactly one record was updated with correct key-sync records
 	assert.Len(suite.T(), entry.SyncStatus, 1) // length should b
-	assert.Equal(suite.T(), "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 }
 
 func (suite *KeySyncSuite) assertVaultServerHasSecret(path string, content map[string]interface{}) {

--- a/internal/yale/yale.go
+++ b/internal/yale/yale.go
@@ -34,8 +34,8 @@ type Yale struct { // Yale config
 type Options struct {
 	// CacheNamespace namespace where Yale will store its cache entries
 	CacheNamespace string
-	// CheckInUseBeforeDisabling if true, Yale will check if a service account is in use before disabling it
-	CheckInUseBeforeDisabling bool
+	// IgnoreUsageMetrics if true, Yale will NOT check if a service account is in use before disabling it
+	IgnoreUsageMetrics bool
 	// SlackWebhookUrl if set, Yale will send slack notifications to this webhook
 	SlackWebhookUrl string
 }
@@ -47,8 +47,8 @@ func NewYale(clients *client.Clients, opts ...func(*Options)) *Yale {
 
 func newYaleFromClients(k8s kubernetes.Interface, crd v1beta1.YaleCRDInterface, iam *iam.Service, metrics *monitoring.MetricClient, vault *vaultapi.Client, opts ...func(*Options)) *Yale {
 	options := Options{
-		CacheNamespace:            cache.DefaultCacheNamespace,
-		CheckInUseBeforeDisabling: true,
+		CacheNamespace:     cache.DefaultCacheNamespace,
+		IgnoreUsageMetrics: false,
 	}
 	for _, opt := range opts {
 		opt(&options)
@@ -267,7 +267,7 @@ func (m *Yale) disableOneKey(keyId string, rotatedAt time.Time, entry *cache.Ent
 }
 
 func (m *Yale) lastAuthTime(keyId string, entry *cache.Entry) (*time.Time, error) {
-	if !m.options.CheckInUseBeforeDisabling {
+	if m.options.IgnoreUsageMetrics {
 		return nil, nil
 	}
 

--- a/internal/yale/yale_test.go
+++ b/internal/yale/yale_test.go
@@ -74,8 +74,8 @@ func (suite *YaleSuite) SetupTest() {
 
 	suite.yale = newYaleFromComponents(
 		Options{
-			CacheNamespace:            cache.DefaultCacheNamespace,
-			CheckInUseBeforeDisabling: true,
+			CacheNamespace:     cache.DefaultCacheNamespace,
+			IgnoreUsageMetrics: false,
 		},
 		suite.cache,
 		suite.resourcemapper,
@@ -369,12 +369,12 @@ func (suite *YaleSuite) TestYaleReturnsErrorIfOldRotatedKeyIsStillInUse() {
 	assert.False(suite.T(), exists)
 }
 
-func (suite *YaleSuite) TestYaleDoesNotCheckIfRotatedKeyIsStillInUseIfCheckInUseOptionIsFalse() {
-	// overwrite default yale instance with one where CheckInUseBeforeDisabling is false
+func (suite *YaleSuite) TestYaleDoesNotCheckIfRotatedKeyIsStillInUseIfIgnoreUsageMetricsIsTrue() {
+	// overwrite default yale instance with one where IgnoreUsageMetrics is true
 	suite.yale = newYaleFromComponents(
 		Options{
-			CacheNamespace:            cache.DefaultCacheNamespace,
-			CheckInUseBeforeDisabling: false,
+			CacheNamespace:     cache.DefaultCacheNamespace,
+			IgnoreUsageMetrics: true,
 		},
 		suite.cache,
 		suite.resourcemapper,
@@ -551,8 +551,8 @@ func (suite *YaleSuite) TestYaleAggregatesAndReportsErrors() {
 	_slack := slackmocks.NewSlackNotifier(suite.T())
 	suite.yale = newYaleFromComponents(
 		Options{
-			CacheNamespace:            cache.DefaultCacheNamespace,
-			CheckInUseBeforeDisabling: false,
+			CacheNamespace:     cache.DefaultCacheNamespace,
+			IgnoreUsageMetrics: false,
 		},
 		suite.cache,
 		suite.resourcemapper,


### PR DESCRIPTION
For a handful of Terra service accounts, the `iam.googleapis.com/service_account/key/authn_events_count metric` metric reports that they are in use when they are not. This seems be related to how they are used; from [Google documentation](https://cloud.google.com/policy-intelligence/docs/service-account-usage-tools#understand-authn):

> Authentication activities include both successful and failed API calls. Authentication activities for service account keys also include any time a system lists the keys while attempting to authenticate a request, even if the system doesn't use the key to authenticate the request. This behavior is most common when using signed URLs for Cloud Storage or when authenticating to third-party applications.

Yale as currently written refuses to rotate keys for these service accounts because of this metric shows that they are in use when they are not; this PR adds a new field, `IgnoreUsageMetrics`, to the GcpSaKey CRD spec that allows us to ignore this metric for select service accounts.

### Testing

This PR includes unit tests. I also manually tested in staging by deploying [the updated CRD](ch-DDO-2864), and setting `ignoreUsageMetrics` to true for the sam staging GcpSaKey. This resulted in Yale to disabling the key.

![Screen Shot 2023-05-23 at 9 24 18 AM](https://github.com/broadinstitute/yale/assets/60902147/36d4aea6-18d7-4527-a7d9-96aca7d1becf)

<img width="617" alt="Screen Shot 2023-05-23 at 9 25 51 AM" src="https://github.com/broadinstitute/yale/assets/60902147/8ede20b2-a04d-4294-b63b-add579ba5073">
