### PR TITLE
[DDO-2874] Rename `GCPSaKey` to `GcpSaKey`

### DIFF
--- a/internal/yale/crd/api/v1beta1/register.go
+++ b/internal/yale/crd/api/v1beta1/register.go
@@ -18,7 +18,7 @@ var (
 
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&GCPSaKey{},
+		&GcpSaKey{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/internal/yale/crd/api/v1beta1/types.go
+++ b/internal/yale/crd/api/v1beta1/types.go
@@ -95,7 +95,7 @@ func (v *VaultReplicationFormat) UnmarshalText(data []byte) error {
 	}
 }
 
-type GCPSaKey struct {
+type GcpSaKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
@@ -106,12 +106,12 @@ type GCPSaKeyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []GCPSaKey `json:"items"`
+	Items []GcpSaKey `json:"items"`
 }
 
 // DeepCopyInto copies all properties of this object into another object of the
 // same type that is provided as a pointer.
-func (in *GCPSaKey) DeepCopyInto(out *GCPSaKey) {
+func (in *GcpSaKey) DeepCopyInto(out *GcpSaKey) {
 	out.TypeMeta = in.TypeMeta
 	out.ObjectMeta = in.ObjectMeta
 	out.Spec = GCPSaKeySpec{
@@ -122,8 +122,8 @@ func (in *GCPSaKey) DeepCopyInto(out *GCPSaKey) {
 }
 
 // DeepCopyObject returns a generically typed copy of an object
-func (in *GCPSaKey) DeepCopyObject() runtime.Object {
-	out := GCPSaKey{}
+func (in *GcpSaKey) DeepCopyObject() runtime.Object {
+	out := GcpSaKey{}
 	in.DeepCopyInto(&out)
 
 	return &out
@@ -135,7 +135,7 @@ func (in *GCPSaKeyList) DeepCopyObject() runtime.Object {
 	out.TypeMeta = in.TypeMeta
 	out.ListMeta = in.ListMeta
 	if in.Items != nil {
-		out.Items = make([]GCPSaKey, len(in.Items))
+		out.Items = make([]GcpSaKey, len(in.Items))
 		for i := range in.Items {
 			in.Items[i].DeepCopyInto(&out.Items[i])
 		}

--- a/internal/yale/crd/clientset/v1beta1/gcpsakey.go
+++ b/internal/yale/crd/clientset/v1beta1/gcpsakey.go
@@ -13,7 +13,7 @@ const endpoint = "gcpsakeys"
 // GcpSaKeyInterface client interface fir interacting with GCP SA keys
 type GcpSaKeyInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.GCPSaKeyList, error)
-	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.GCPSaKey, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1.GcpSaKey, error)
 }
 
 type gcpsakeyClient struct {
@@ -32,8 +32,8 @@ func (c *gcpsakeyClient) List(ctx context.Context, opts metav1.ListOptions) (*v1
 	return &result, err
 }
 
-func (c *gcpsakeyClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.GCPSaKey, error) {
-	result := v1.GCPSaKey{}
+func (c *gcpsakeyClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.GcpSaKey, error) {
+	result := v1.GcpSaKey{}
 	err := c.restClient.
 		Get().
 		Resource(endpoint).

--- a/internal/yale/crd/clientset/v1beta1/mocks/gcpsakey.go
+++ b/internal/yale/crd/clientset/v1beta1/mocks/gcpsakey.go
@@ -25,19 +25,19 @@ func (_m *GcpSaKeyInterface) EXPECT() *GcpSaKeyInterface_Expecter {
 }
 
 // Get provides a mock function with given fields: ctx, name, options
-func (_m *GcpSaKeyInterface) Get(ctx context.Context, name string, options v1.GetOptions) (*v1beta1.GCPSaKey, error) {
+func (_m *GcpSaKeyInterface) Get(ctx context.Context, name string, options v1.GetOptions) (*v1beta1.GcpSaKey, error) {
 	ret := _m.Called(ctx, name, options)
 
-	var r0 *v1beta1.GCPSaKey
+	var r0 *v1beta1.GcpSaKey
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, v1.GetOptions) (*v1beta1.GCPSaKey, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, v1.GetOptions) (*v1beta1.GcpSaKey, error)); ok {
 		return rf(ctx, name, options)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, v1.GetOptions) *v1beta1.GCPSaKey); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, v1.GetOptions) *v1beta1.GcpSaKey); ok {
 		r0 = rf(ctx, name, options)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1beta1.GCPSaKey)
+			r0 = ret.Get(0).(*v1beta1.GcpSaKey)
 		}
 	}
 
@@ -70,12 +70,12 @@ func (_c *GcpSaKeyInterface_Get_Call) Run(run func(ctx context.Context, name str
 	return _c
 }
 
-func (_c *GcpSaKeyInterface_Get_Call) Return(_a0 *v1beta1.GCPSaKey, _a1 error) *GcpSaKeyInterface_Get_Call {
+func (_c *GcpSaKeyInterface_Get_Call) Return(_a0 *v1beta1.GcpSaKey, _a1 error) *GcpSaKeyInterface_Get_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *GcpSaKeyInterface_Get_Call) RunAndReturn(run func(context.Context, string, v1.GetOptions) (*v1beta1.GCPSaKey, error)) *GcpSaKeyInterface_Get_Call {
+func (_c *GcpSaKeyInterface_Get_Call) RunAndReturn(run func(context.Context, string, v1.GetOptions) (*v1beta1.GcpSaKey, error)) *GcpSaKeyInterface_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/yale/cutoff/cutoff.go
+++ b/internal/yale/cutoff/cutoff.go
@@ -53,11 +53,11 @@ func NewWithDefaults() Cutoffs {
 	return newWithThresholds(minimums, time.Now())
 }
 
-func New(gsks ...apiv1b1.GCPSaKey) Cutoffs {
+func New(gsks ...apiv1b1.GcpSaKey) Cutoffs {
 	return newWithCustomTime(gsks, time.Now())
 }
 
-func newWithCustomTime(gsks []apiv1b1.GCPSaKey, now time.Time) cutoffs {
+func newWithCustomTime(gsks []apiv1b1.GcpSaKey, now time.Time) cutoffs {
 	if len(gsks) < 1 {
 		panic("at least one GcpSaKey must be supplied in order to compute cutoffs")
 	}
@@ -135,15 +135,15 @@ func (c cutoffs) daysAgo(n int) time.Time {
 }
 
 // computeThresholds take a set of gsks and collapse them into a set of agreed-upon thresholds
-func computeThresholds(gsks []apiv1b1.GCPSaKey) thresholds {
+func computeThresholds(gsks []apiv1b1.GcpSaKey) thresholds {
 	t := thresholds{
-		rotateAfter: computeThreshold(gsks, func(gsk apiv1b1.GCPSaKey) int {
+		rotateAfter: computeThreshold(gsks, func(gsk apiv1b1.GcpSaKey) int {
 			return gsk.Spec.KeyRotation.RotateAfter
 		}, minimums.rotateAfter, "RotateAfter"),
-		disableAfter: computeThreshold(gsks, func(gsk apiv1b1.GCPSaKey) int {
+		disableAfter: computeThreshold(gsks, func(gsk apiv1b1.GcpSaKey) int {
 			return gsk.Spec.KeyRotation.DisableAfter
 		}, minimums.disableAfter, "DisableAfter"),
-		deleteAfter: computeThreshold(gsks, func(gsk apiv1b1.GCPSaKey) int {
+		deleteAfter: computeThreshold(gsks, func(gsk apiv1b1.GcpSaKey) int {
 			return gsk.Spec.KeyRotation.DeleteAfter
 		}, minimums.deleteAfter, "DeleteAfter"),
 		ignoreUsageMetrics: computeIgnoreUsageMetrics(gsks),
@@ -156,7 +156,7 @@ func computeThresholds(gsks []apiv1b1.GCPSaKey) thresholds {
 
 // computeThreshold take the rotate/disable/delete days values from a list of GSKs and return the lowest value,
 // rounding up to the hardcoded minimums/floors for each attribute if necessary
-func computeThreshold(gsks []apiv1b1.GCPSaKey, fieldFn func(apiv1b1.GCPSaKey) int, floor int, fieldName string) int {
+func computeThreshold(gsks []apiv1b1.GcpSaKey, fieldFn func(apiv1b1.GcpSaKey) int, floor int, fieldName string) int {
 	min := gsks[0]
 	for _, gsk := range gsks {
 		v := fieldFn(gsk)
@@ -175,7 +175,7 @@ func computeThreshold(gsks []apiv1b1.GCPSaKey, fieldFn func(apiv1b1.GCPSaKey) in
 	return minV
 }
 
-func computeIgnoreUsageMetrics(gsks []apiv1b1.GCPSaKey) bool {
+func computeIgnoreUsageMetrics(gsks []apiv1b1.GcpSaKey) bool {
 	if len(gsks) == 0 {
 		return false
 	}

--- a/internal/yale/cutoff/cutoff_test.go
+++ b/internal/yale/cutoff/cutoff_test.go
@@ -174,7 +174,7 @@ func Test_Cutoffs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gsk := v1beta1.GCPSaKey{
+			gsk := v1beta1.GcpSaKey{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-gsk",
 					Namespace: "test-namespace",
@@ -183,7 +183,7 @@ func Test_Cutoffs(t *testing.T) {
 					KeyRotation: tc.input,
 				},
 			}
-			c := newWithCustomTime([]v1beta1.GCPSaKey{gsk}, now)
+			c := newWithCustomTime([]v1beta1.GcpSaKey{gsk}, now)
 
 			assert.Equal(t, tc.expectedThresholds.rotateAfter, c.RotateAfterDays())
 			assert.Equal(t, tc.expectedThresholds.disableAfter, c.DisableAfterDays())
@@ -210,12 +210,12 @@ func Test_Cutoffs(t *testing.T) {
 func Test_computeThresholds(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    []v1beta1.GCPSaKey
+		input    []v1beta1.GcpSaKey
 		expected thresholds
 	}{
 		{
 			name: "should return correct thresholds for a single gsk",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-gsk-1",
@@ -241,7 +241,7 @@ func Test_computeThresholds(t *testing.T) {
 		},
 		{
 			name: "should round up to configured minimums",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-gsk-1",
@@ -267,7 +267,7 @@ func Test_computeThresholds(t *testing.T) {
 		},
 		{
 			name: "should choose minimum valid value for multiple conflicting GSK specs",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-gsk-1",
@@ -351,17 +351,17 @@ func Test_computeThresholds(t *testing.T) {
 func Test_computeIgnoreUsageMetrics(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    []v1beta1.GCPSaKey
+		input    []v1beta1.GcpSaKey
 		expected bool
 	}{
 		{
 			name:     "empty",
-			input:    []v1beta1.GCPSaKey{},
+			input:    []v1beta1.GcpSaKey{},
 			expected: false,
 		},
 		{
 			name: "single gsk with ignoreUsageMetrics set to false",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gsk-1",
@@ -378,7 +378,7 @@ func Test_computeIgnoreUsageMetrics(t *testing.T) {
 		},
 		{
 			name: "single gsk with ignoreUsageMetrics set to true",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gsk-1",
@@ -395,7 +395,7 @@ func Test_computeIgnoreUsageMetrics(t *testing.T) {
 		},
 		{
 			name: "multiple gsks with ignoreUsageMetrics set to true",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gsk-1",
@@ -434,7 +434,7 @@ func Test_computeIgnoreUsageMetrics(t *testing.T) {
 		},
 		{
 			name: "multiple gsks with ignoreUsageMetrics set to false",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gsk-1",
@@ -473,7 +473,7 @@ func Test_computeIgnoreUsageMetrics(t *testing.T) {
 		},
 		{
 			name: "multiple gsks with ignoreUsageMetrics set to true and false",
-			input: []v1beta1.GCPSaKey{
+			input: []v1beta1.GcpSaKey{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gsk-1",

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -58,7 +58,7 @@ func (suite *KeySyncSuite) Test_KeySync_CreatesK8sSecret() {
 	entry.CurrentKey.ID = key1.id
 	entry.SyncStatus = map[string]string{} // no prior syncs recorded in the map
 
-	gsk := apiv1b1.GCPSaKey{
+	gsk := apiv1b1.GcpSaKey{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gsk",
 			Namespace: "my-namespace",
@@ -114,7 +114,7 @@ func (suite *KeySyncSuite) Test_KeySync_UpdatesK8sSecretIfAlreadyExists() {
 	entry.CurrentKey.ID = key1.id
 	entry.SyncStatus = map[string]string{} // no prior syncs recorded in the map
 
-	gsk := apiv1b1.GCPSaKey{
+	gsk := apiv1b1.GcpSaKey{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gsk",
 			Namespace: "my-namespace",
@@ -182,7 +182,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsAllConfiguredVaultReplications()
 	entry.CurrentKey.ID = key1.id
 	entry.SyncStatus = map[string]string{} // no prior syncs recorded in the map
 
-	gsk := apiv1b1.GCPSaKey{
+	gsk := apiv1b1.GcpSaKey{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gsk",
 			Namespace: "my-namespace",
@@ -260,7 +260,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsASyncIfSyncStatusIsUpToDateButSe
 		"my-namespace/my-gsk": "515a2a04abd78d13b0df1e4bc0163e1a787439fd968f364794083fa995fed009:" + key1.id,
 	}
 
-	gsk := apiv1b1.GCPSaKey{
+	gsk := apiv1b1.GcpSaKey{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gsk",
 			Namespace: "my-namespace",
@@ -302,7 +302,7 @@ func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformASyncIfSyncStatusIsUpToDat
 		"my-namespace/my-gsk": "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:" + key1.id,
 	}
 
-	gsk := apiv1b1.GCPSaKey{
+	gsk := apiv1b1.GcpSaKey{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gsk",
 			Namespace: "my-namespace",
@@ -352,7 +352,7 @@ func (suite *KeySyncSuite) Test_KeySync_PrunesOldStatusEntries() {
 		"other-namespace/deleted-gsk": "bcb8be041cfe2fc4da92ced123f56cb2cc1d6eeb10175d2b4e4348a16c2c235f:" + key1.id, // should be deleted
 	}
 
-	gsk := apiv1b1.GCPSaKey{
+	gsk := apiv1b1.GcpSaKey{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-gsk",
 			Namespace: "my-namespace",

--- a/internal/yale/keysync/mocks/keysync.go
+++ b/internal/yale/keysync/mocks/keysync.go
@@ -24,7 +24,7 @@ func (_m *KeySync) EXPECT() *KeySync_Expecter {
 }
 
 // SyncIfNeeded provides a mock function with given fields: entry, gsks
-func (_m *KeySync) SyncIfNeeded(entry *cache.Entry, gsks ...v1beta1.GCPSaKey) error {
+func (_m *KeySync) SyncIfNeeded(entry *cache.Entry, gsks ...v1beta1.GcpSaKey) error {
 	_va := make([]interface{}, len(gsks))
 	for _i := range gsks {
 		_va[_i] = gsks[_i]
@@ -35,7 +35,7 @@ func (_m *KeySync) SyncIfNeeded(entry *cache.Entry, gsks ...v1beta1.GCPSaKey) er
 	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*cache.Entry, ...v1beta1.GCPSaKey) error); ok {
+	if rf, ok := ret.Get(0).(func(*cache.Entry, ...v1beta1.GcpSaKey) error); ok {
 		r0 = rf(entry, gsks...)
 	} else {
 		r0 = ret.Error(0)
@@ -51,18 +51,18 @@ type KeySync_SyncIfNeeded_Call struct {
 
 // SyncIfNeeded is a helper method to define mock.On call
 //   - entry *cache.Entry
-//   - gsks ...v1beta1.GCPSaKey
+//   - gsks ...v1beta1.GcpSaKey
 func (_e *KeySync_Expecter) SyncIfNeeded(entry interface{}, gsks ...interface{}) *KeySync_SyncIfNeeded_Call {
 	return &KeySync_SyncIfNeeded_Call{Call: _e.mock.On("SyncIfNeeded",
 		append([]interface{}{entry}, gsks...)...)}
 }
 
-func (_c *KeySync_SyncIfNeeded_Call) Run(run func(entry *cache.Entry, gsks ...v1beta1.GCPSaKey)) *KeySync_SyncIfNeeded_Call {
+func (_c *KeySync_SyncIfNeeded_Call) Run(run func(entry *cache.Entry, gsks ...v1beta1.GcpSaKey)) *KeySync_SyncIfNeeded_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]v1beta1.GCPSaKey, len(args)-1)
+		variadicArgs := make([]v1beta1.GcpSaKey, len(args)-1)
 		for i, a := range args[1:] {
 			if a != nil {
-				variadicArgs[i] = a.(v1beta1.GCPSaKey)
+				variadicArgs[i] = a.(v1beta1.GcpSaKey)
 			}
 		}
 		run(args[0].(*cache.Entry), variadicArgs...)
@@ -75,7 +75,7 @@ func (_c *KeySync_SyncIfNeeded_Call) Return(_a0 error) *KeySync_SyncIfNeeded_Cal
 	return _c
 }
 
-func (_c *KeySync_SyncIfNeeded_Call) RunAndReturn(run func(*cache.Entry, ...v1beta1.GCPSaKey) error) *KeySync_SyncIfNeeded_Call {
+func (_c *KeySync_SyncIfNeeded_Call) RunAndReturn(run func(*cache.Entry, ...v1beta1.GcpSaKey) error) *KeySync_SyncIfNeeded_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/yale/resourcemap/resourcemap.go
+++ b/internal/yale/resourcemap/resourcemap.go
@@ -13,7 +13,7 @@ import (
 // Bundle represents a bundle of resources associated with a specific service account
 type Bundle struct {
 	Entry *cache.Entry
-	GSKs  []v1beta1.GCPSaKey
+	GSKs  []v1beta1.GcpSaKey
 }
 
 // Mapper inspects all the GcpSaKeys and Cache entries in the cluster and organizes
@@ -102,13 +102,13 @@ func (m *mapper) Build() (map[string]*Bundle, error) {
 }
 
 // listGcpSaKeys retrieves a list of GcpSaKey resources in the cluster, discaring any invalid ones
-func (m *mapper) listGcpSaKeys() ([]v1beta1.GCPSaKey, error) {
+func (m *mapper) listGcpSaKeys() ([]v1beta1.GcpSaKey, error) {
 	list, err := m.crd.GcpSaKeys().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving list of Yale CRDs from cluster: %v", err)
 	}
 
-	var result []v1beta1.GCPSaKey
+	var result []v1beta1.GcpSaKey
 
 	for _, gsk := range list.Items {
 		if gsk.Spec.GoogleServiceAccount.Name == "" {

--- a/internal/yale/resourcemap/resourcemap_test.go
+++ b/internal/yale/resourcemap/resourcemap_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-var gsk1a = v1beta1.GCPSaKey{
+var gsk1a = v1beta1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gsk-1",
 		Namespace: "ns-a",
@@ -25,7 +25,7 @@ var gsk1a = v1beta1.GCPSaKey{
 	},
 }
 
-var gsk1b = v1beta1.GCPSaKey{
+var gsk1b = v1beta1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gsk-1",
 		Namespace: "ns-a",
@@ -38,7 +38,7 @@ var gsk1b = v1beta1.GCPSaKey{
 	},
 }
 
-var gsk2a = v1beta1.GCPSaKey{
+var gsk2a = v1beta1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gsk-2",
 		Namespace: "ns-a",
@@ -51,7 +51,7 @@ var gsk2a = v1beta1.GCPSaKey{
 	},
 }
 
-var gsk2b = v1beta1.GCPSaKey{
+var gsk2b = v1beta1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gsk-2",
 		Namespace: "ns-b",
@@ -64,7 +64,7 @@ var gsk2b = v1beta1.GCPSaKey{
 	},
 }
 
-var gsk2bBroken = v1beta1.GCPSaKey{
+var gsk2bBroken = v1beta1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gsk-2",
 		Namespace: "ns-b",
@@ -77,7 +77,7 @@ var gsk2bBroken = v1beta1.GCPSaKey{
 	},
 }
 
-var gsk4a = v1beta1.GCPSaKey{
+var gsk4a = v1beta1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gsk-4",
 		Namespace: "ns-a",
@@ -130,7 +130,7 @@ func Test_Build(t *testing.T) {
 		name                 string
 		existingCacheEntries []*cache.Entry
 		newCacheEntries      []*cache.Entry
-		gsks                 []v1beta1.GCPSaKey
+		gsks                 []v1beta1.GcpSaKey
 		expected             map[string]*Bundle
 		expectErr            string
 	}{
@@ -140,72 +140,72 @@ func Test_Build(t *testing.T) {
 		},
 		{
 			name:            "empty cache, one gsk in cluster",
-			gsks:            []v1beta1.GCPSaKey{gsk1a},
+			gsks:            []v1beta1.GcpSaKey{gsk1a},
 			newCacheEntries: []*cache.Entry{entry1},
 			expected: map[string]*Bundle{
 				"sa-1@p.com": {
 					Entry: entry1, // new entry created for sa-1
-					GSKs:  []v1beta1.GCPSaKey{gsk1a},
+					GSKs:  []v1beta1.GcpSaKey{gsk1a},
 				},
 			},
 		},
 		{
 			name:                 "one cache entry cache, matches one gsk in cluster",
-			gsks:                 []v1beta1.GCPSaKey{gsk1a},
+			gsks:                 []v1beta1.GcpSaKey{gsk1a},
 			existingCacheEntries: []*cache.Entry{entry1},
 			expected: map[string]*Bundle{
 				"sa-1@p.com": {
 					Entry: entry1,
-					GSKs:  []v1beta1.GCPSaKey{gsk1a},
+					GSKs:  []v1beta1.GcpSaKey{gsk1a},
 				},
 			},
 		},
 		{
 			name:                 "one cache entry cache, matches two gsks in cluster",
-			gsks:                 []v1beta1.GCPSaKey{gsk1a, gsk1b},
+			gsks:                 []v1beta1.GcpSaKey{gsk1a, gsk1b},
 			existingCacheEntries: []*cache.Entry{entry1},
 			expected: map[string]*Bundle{
 				"sa-1@p.com": {
 					Entry: entry1,
-					GSKs:  []v1beta1.GCPSaKey{gsk1a, gsk1b},
+					GSKs:  []v1beta1.GcpSaKey{gsk1a, gsk1b},
 				},
 			},
 		},
 		{
 			name:                 "broken cache entry should lead service account to be skipped",
-			gsks:                 []v1beta1.GCPSaKey{gsk1a, gsk2a, gsk2b},
+			gsks:                 []v1beta1.GcpSaKey{gsk1a, gsk2a, gsk2b},
 			existingCacheEntries: []*cache.Entry{entry1, entry2Broken},
 			expected: map[string]*Bundle{
 				"sa-1@p.com": {
 					Entry: entry1,
-					GSKs:  []v1beta1.GCPSaKey{gsk1a},
+					GSKs:  []v1beta1.GcpSaKey{gsk1a},
 				},
 			},
 		},
 		{
 			name:                 "broken gsk should lead service account to be skipped",
-			gsks:                 []v1beta1.GCPSaKey{gsk1a, gsk1b, gsk2a, gsk2bBroken},
+			gsks:                 []v1beta1.GcpSaKey{gsk1a, gsk1b, gsk2a, gsk2bBroken},
 			existingCacheEntries: []*cache.Entry{entry1, entry2},
 			expected: map[string]*Bundle{
 				"sa-1@p.com": {
 					Entry: entry1,
-					GSKs:  []v1beta1.GCPSaKey{gsk1a, gsk1b},
+					GSKs:  []v1beta1.GcpSaKey{gsk1a, gsk1b},
 				},
 			},
 		},
 		{
 			name:                 "multiple entries and gsks",
-			gsks:                 []v1beta1.GCPSaKey{gsk1a, gsk1b, gsk2a, gsk2b, gsk4a},
+			gsks:                 []v1beta1.GcpSaKey{gsk1a, gsk1b, gsk2a, gsk2b, gsk4a},
 			existingCacheEntries: []*cache.Entry{entry1, entry2, entry3},
 			newCacheEntries:      []*cache.Entry{entry4},
 			expected: map[string]*Bundle{
 				"sa-1@p.com": {
 					Entry: entry1,
-					GSKs:  []v1beta1.GCPSaKey{gsk1a, gsk1b},
+					GSKs:  []v1beta1.GcpSaKey{gsk1a, gsk1b},
 				},
 				"sa-2@p.com": {
 					Entry: entry2,
-					GSKs:  []v1beta1.GCPSaKey{gsk2a, gsk2b},
+					GSKs:  []v1beta1.GcpSaKey{gsk2a, gsk2b},
 				},
 				"sa-3@p.com": {
 					Entry: entry3,
@@ -213,7 +213,7 @@ func Test_Build(t *testing.T) {
 				},
 				"sa-4@p.com": {
 					Entry: entry4, // new entry created for sa-4
-					GSKs:  []v1beta1.GCPSaKey{gsk4a},
+					GSKs:  []v1beta1.GcpSaKey{gsk4a},
 				},
 			},
 		},
@@ -275,7 +275,7 @@ func Test_validateResourceBundle(t *testing.T) {
 		{
 			name: "should not error if bundle has gsk only",
 			input: &Bundle{
-				GSKs: []v1beta1.GCPSaKey{
+				GSKs: []v1beta1.GcpSaKey{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "gsk-1",
@@ -300,7 +300,7 @@ func Test_validateResourceBundle(t *testing.T) {
 						Project: "p",
 					},
 				},
-				GSKs: []v1beta1.GCPSaKey{
+				GSKs: []v1beta1.GcpSaKey{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "gsk-1",
@@ -325,7 +325,7 @@ func Test_validateResourceBundle(t *testing.T) {
 						Project: "p",
 					},
 				},
-				GSKs: []v1beta1.GCPSaKey{
+				GSKs: []v1beta1.GcpSaKey{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "gsk-1",
@@ -361,7 +361,7 @@ func Test_validateResourceBundle(t *testing.T) {
 						Project: "p",
 					},
 				},
-				GSKs: []v1beta1.GCPSaKey{
+				GSKs: []v1beta1.GcpSaKey{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "gsk-1",
@@ -386,7 +386,7 @@ func Test_validateResourceBundle(t *testing.T) {
 						Project: "p",
 					},
 				},
-				GSKs: []v1beta1.GCPSaKey{
+				GSKs: []v1beta1.GcpSaKey{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "gsk-1",

--- a/internal/yale/yale.go
+++ b/internal/yale/yale.go
@@ -101,7 +101,7 @@ func (m *Yale) Run() error {
 	return nil
 }
 
-func (m *Yale) processServiceAccountAndReportErrors(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) error {
+func (m *Yale) processServiceAccountAndReportErrors(entry *cache.Entry, gsks []apiv1b1.GcpSaKey) error {
 	if err := m.processServiceAccount(entry, gsks); err != nil {
 		if reportErr := m.reportError(entry, err); reportErr != nil {
 			logs.Error.Printf("error reporting error for service account %s: %v", entry.ServiceAccount.Email, reportErr)
@@ -111,7 +111,7 @@ func (m *Yale) processServiceAccountAndReportErrors(entry *cache.Entry, gsks []a
 	return nil
 }
 
-func (m *Yale) processServiceAccount(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) error {
+func (m *Yale) processServiceAccount(entry *cache.Entry, gsks []apiv1b1.GcpSaKey) error {
 	var err error
 
 	cutoffs := m.computeCutoffs(entry, gsks)
@@ -137,7 +137,7 @@ func (m *Yale) processServiceAccount(entry *cache.Entry, gsks []apiv1b1.GCPSaKey
 
 // computeCutoffs computes the cutoffs for key rotation/disabling/deletion based on the GcpSaKey resources
 // for this service account
-func (m *Yale) computeCutoffs(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) cutoff.Cutoffs {
+func (m *Yale) computeCutoffs(entry *cache.Entry, gsks []apiv1b1.GcpSaKey) cutoff.Cutoffs {
 	if len(gsks) == 0 {
 		logs.Info.Printf("cache entry for %s has no corresponding GcpSaKey resources in the cluster; will use Yale's default cutoffs to retire old keys", entry.ServiceAccount.Email)
 		return cutoff.NewWithDefaults()
@@ -146,7 +146,7 @@ func (m *Yale) computeCutoffs(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) cutof
 }
 
 // syncKeyIfReady if cache entry has a current/active key, perform a keysync
-func (m *Yale) syncKeyIfReady(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) error {
+func (m *Yale) syncKeyIfReady(entry *cache.Entry, gsks []apiv1b1.GcpSaKey) error {
 	if len(entry.CurrentKey.ID) == 0 {
 		// nothing to sync yet
 		return nil
@@ -155,7 +155,7 @@ func (m *Yale) syncKeyIfReady(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) error
 }
 
 // rotateKey rotates the current active key for the service account, if needed.
-func (m *Yale) rotateKey(entry *cache.Entry, cutoffs cutoff.Cutoffs, gsks []apiv1b1.GCPSaKey) error {
+func (m *Yale) rotateKey(entry *cache.Entry, cutoffs cutoff.Cutoffs, gsks []apiv1b1.GcpSaKey) error {
 	rotated, err := m.issueNewKeyIfNeeded(entry, cutoffs, gsks)
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func (m *Yale) rotateKey(entry *cache.Entry, cutoffs cutoff.Cutoffs, gsks []apiv
 // if a rotation is needed (or the cache entry is new/empty), it issues a new sa key, adds it
 // to the cache entry, then saves the updated cache entry to k8s.
 // returns a boolean that will be true if a new key was issued, false otherwise
-func (m *Yale) issueNewKeyIfNeeded(entry *cache.Entry, cutoffs cutoff.Cutoffs, gsks []apiv1b1.GCPSaKey) (bool, error) {
+func (m *Yale) issueNewKeyIfNeeded(entry *cache.Entry, cutoffs cutoff.Cutoffs, gsks []apiv1b1.GcpSaKey) (bool, error) {
 	issued := false
 	email := entry.ServiceAccount.Email
 	project := entry.ServiceAccount.Project
@@ -324,7 +324,7 @@ func (m *Yale) deleteOneKey(keyId string, disabledAt time.Time, entry *cache.Ent
 	return m.slack.KeyDeleted(entry, key.ID)
 }
 
-func (m *Yale) retireCacheEntryIfNeeded(entry *cache.Entry, gsks []apiv1b1.GCPSaKey) error {
+func (m *Yale) retireCacheEntryIfNeeded(entry *cache.Entry, gsks []apiv1b1.GcpSaKey) error {
 	if len(gsks) > 0 {
 		return nil
 	}

--- a/internal/yale/yale_test.go
+++ b/internal/yale/yale_test.go
@@ -141,7 +141,7 @@ var sa3key1 = key{
 	pem: "dog",
 }
 
-var gsk1 = apiv1b1.GCPSaKey{
+var gsk1 = apiv1b1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "s1-gsk",
 		Namespace: "ns-1",
@@ -164,7 +164,7 @@ var gsk1 = apiv1b1.GCPSaKey{
 	},
 }
 
-var gsk2 = apiv1b1.GCPSaKey{
+var gsk2 = apiv1b1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "s2-gsk",
 		Namespace: "ns-2",
@@ -187,7 +187,7 @@ var gsk2 = apiv1b1.GCPSaKey{
 	},
 }
 
-var gsk3 = apiv1b1.GCPSaKey{
+var gsk3 = apiv1b1.GcpSaKey{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "s3-gsk",
 		Namespace: "ns-3",
@@ -621,7 +621,7 @@ func (suite *YaleSuite) TestYaleAggregatesAndReportsErrors() {
 	assert.Equal(suite.T(), lastNotification, entry.LastError.LastNotificationAt)
 }
 
-func (suite *YaleSuite) seedGsks(gsks ...apiv1b1.GCPSaKey) {
+func (suite *YaleSuite) seedGsks(gsks ...apiv1b1.GcpSaKey) {
 	suite.gskEndpoint.EXPECT().List(mock.Anything, metav1.ListOptions{}).Return(&apiv1b1.GCPSaKeyList{
 		Items: gsks,
 	}, nil)


### PR DESCRIPTION
Rename Golang type `GCPSaKey` to `GcpSaKey`, which is how we represent it in YAML manifests.

This is necessary in order to get parsing working correctly for the reloader linter, and it seems like a good idea generally.

### Testing

Yale's unit tests are passing. I will also manually deploy this PR to the BEE cluster and verify Yale continues to work as expected before merging.