### PR TITLE
[DDO-2969] Ignores for Yale linter

### DIFF
--- a/internal/tools/linter/ignore.go
+++ b/internal/tools/linter/ignore.go
@@ -1,0 +1,43 @@
+package linter
+
+import "strings"
+
+const ignoreAnnotation = "yale.terra.bio/linter-ignore"
+
+const ignoreAll = "all"
+
+type ignoreCfg struct {
+	all     bool
+	secrets map[string]struct{}
+}
+
+func parseIgnoreAnnotations(annotations map[string]string) ignoreCfg {
+	cfg := ignoreCfg{
+		all:     false,
+		secrets: make(map[string]struct{}),
+	}
+
+	value, exists := annotations[ignoreAnnotation]
+	if !exists {
+		return cfg
+	}
+
+	for _, token := range strings.Split(value, ",") {
+		token = strings.TrimSpace(token)
+		if token == ignoreAll {
+			cfg.all = true
+		} else {
+			cfg.secrets[token] = struct{}{}
+		}
+	}
+
+	return cfg
+}
+
+func (i ignoreCfg) ignoresSecret(name string) bool {
+	if i.all {
+		return true
+	}
+	_, exists := i.secrets[name]
+	return exists
+}

--- a/internal/tools/linter/ignore_test.go
+++ b/internal/tools/linter/ignore_test.go
@@ -1,0 +1,36 @@
+package linter
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_parseIgnore(t *testing.T) {
+	var i ignoreCfg
+
+	i = parseIgnoreAnnotations(map[string]string{})
+	assert.False(t, i.all)
+	assert.Empty(t, i.secrets)
+	assert.False(t, i.ignoresSecret("foo"))
+
+	i = parseIgnoreAnnotations(map[string]string{
+		"yale.terra.bio/linter-ignore": "all",
+	})
+	assert.True(t, i.all)
+	assert.Empty(t, i.secrets)
+	assert.True(t, i.ignoresSecret("foo"))
+
+	i = parseIgnoreAnnotations(map[string]string{
+		"yale.terra.bio/linter-ignore": "baz, all ,bar",
+	})
+	assert.True(t, i.all)
+	assert.Equal(t, 2, len(i.secrets))
+	assert.True(t, i.ignoresSecret("foo"))
+
+	i = parseIgnoreAnnotations(map[string]string{
+		"yale.terra.bio/linter-ignore": "baz, foo ,bar",
+	})
+	assert.False(t, i.all)
+	assert.Equal(t, 3, len(i.secrets))
+	assert.True(t, i.ignoresSecret("foo"))
+}

--- a/internal/tools/linter/linter.go
+++ b/internal/tools/linter/linter.go
@@ -109,6 +109,8 @@ func scan[T any](r resource[T], secrets []secret) []reference {
 
 	reloader := parseReloaderAnnotations(r.annotations)
 
+	ignore := parseIgnoreAnnotations(r.annotations)
+
 	scanner := bufio.NewScanner(bytes.NewReader(r.document.content))
 	var lineoffset int
 	for scanner.Scan() {
@@ -133,8 +135,12 @@ func scan[T any](r resource[T], secrets []secret) []reference {
 				logs.Debug.Printf("%s: will reload (%s)", ref.summarize(), reason)
 				continue
 			}
-
-			logs.Debug.Printf("%s: WILL NOT reload on changes", ref.summarize())
+			logs.Info.Printf("%s: WILL NOT reload on changes", ref.summarize())
+			fmt.Println("why this is not working?")
+			if ignore.ignoresSecret(s.name) {
+				logs.Info.Printf("%s: ignoring missing reloader annotation", ref.summarize())
+				continue
+			}
 
 			matches = append(matches, ref)
 		}

--- a/internal/tools/linter/linter_test.go
+++ b/internal/tools/linter/linter_test.go
@@ -101,6 +101,9 @@ func Test_Linter(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "simple-missing-with-ignore",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/tools/linter/testdata/simple-missing-with-ignore/deployment.yaml
+++ b/internal/tools/linter/testdata/simple-missing-with-ignore/deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-1
+  annotations:
+    yale.terra.bio/linter-ignore: "gsk-1-secret"
+spec:
+  template:
+    spec:
+      containers:
+      - name: deployment-1
+        envFrom:
+          - secretRef:
+              name: gsk-1-secret

--- a/internal/tools/linter/testdata/simple-missing-with-ignore/gsk.yaml
+++ b/internal/tools/linter/testdata/simple-missing-with-ignore/gsk.yaml
@@ -1,0 +1,7 @@
+apiVersion: yale.broadinstitute.org/v1beta1
+kind: GcpSaKey
+metadata:
+  name: gsk-1
+spec:
+  secret:
+    name: gsk-1-secret


### PR DESCRIPTION
Make it possible to configure the Yale linter to ignore missing reloader annotations.

To set up an ignore, simply annotate the affected statefulset or deployment with `yale.terra.bio/linter-ignore`. Possible values include `all` (ignore all missing annotations) or a list of secret names (eg.`my-gsk-secret-1, my-gsk-secret-2`).

### Testing

This PR includes unit test coverage.

### Why?

The new [postgres auto-upgrade process](https://github.com/broadinstitute/terra-helmfile/pull/4377) uses a service account key in an init container. The Yale linter detects this and returns an error because it thinks there's a missing reloader annotation, but in fact we do not want to restart the database whenever this key is rotated.