### PR TITLE
[DDO-2999] Daily rotation window

### DIFF
--- a/cmd/yale/main.go
+++ b/cmd/yale/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/broadinstitute/yale/internal/yale"
 	"github.com/broadinstitute/yale/internal/yale/cache"
 	"github.com/broadinstitute/yale/internal/yale/client"
@@ -10,6 +11,10 @@ import (
 	"k8s.io/client-go/util/homedir"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type args struct {
@@ -18,6 +23,8 @@ type args struct {
 	kubeconfig         string
 	cacheNamespace     string
 	ignoreUsageMetrics bool
+	windowStart        string
+	windowEnd          string
 }
 
 func main() {
@@ -29,10 +36,17 @@ func main() {
 	if err != nil {
 		logs.Error.Fatalf("Error building clients: %v, exiting\n", err)
 	}
+
+	window, err := parseRotateWindow(args, time.Now())
+	if err != nil {
+		logs.Error.Fatal(err)
+	}
+
 	m := yale.NewYale(clients, func(options *yale.Options) {
 		options.CacheNamespace = args.cacheNamespace
 		options.IgnoreUsageMetrics = args.ignoreUsageMetrics
 		options.SlackWebhookUrl = os.Getenv(slack.WebhookEnvVar)
+		options.RotateWindow = *window
 	})
 	if err = m.Run(); err != nil {
 		logs.Error.Fatal(err)
@@ -49,6 +63,69 @@ func parseArgs() *args {
 	local := flag.Bool("local", false, "use this flag when running locally (outside of cluster to use local kube config")
 	cacheNamespace := flag.String("cachenamespace", cache.DefaultCacheNamespace, "namespace where yale should cache service account keys")
 	ignoreUsageMetrics := flag.Bool("ignoreusagemetrics", false, "do not check if service account key is in use before disabling")
+	windowStart := flag.String("window-start", "", "use to restrict rotation to a particular time of day (HH:MM). eg. 05:00")
+	windowEnd := flag.String("window-end", "", "use to restrict rotation to a particular time of day (HH:MM). eg. 06:00")
 	flag.Parse()
-	return &args{*local, *kubeconfig, *cacheNamespace, *ignoreUsageMetrics}
+	return &args{
+		*local,
+		*kubeconfig,
+		*cacheNamespace,
+		*ignoreUsageMetrics,
+		*windowStart,
+		*windowEnd,
+	}
+}
+
+func parseRotateWindow(args *args, now time.Time) (*yale.RotateWindow, error) {
+	if args.windowStart == "" {
+		if args.windowEnd == "" {
+			return &yale.RotateWindow{
+				Enabled: false,
+			}, nil
+		} else {
+			return nil, fmt.Errorf("-window-end requires -window-start")
+		}
+	} else {
+		if args.windowEnd == "" {
+			return nil, fmt.Errorf("-window-start requires -window-end")
+		}
+	}
+
+	start, err := parseWindowBoundary(args.windowStart, now)
+	if err != nil {
+		return nil, fmt.Errorf("-window-start: %v", err)
+	}
+
+	end, err := parseWindowBoundary(args.windowEnd, now)
+	if err != nil {
+		return nil, fmt.Errorf("-window-end: %v", err)
+	}
+
+	return &yale.RotateWindow{
+		Enabled:   true,
+		StartTime: *start,
+		EndTime:   *end,
+	}, nil
+}
+
+var rotateWindowRegexp = regexp.MustCompile("^[0-9]{2}:[0-9]{2}$")
+
+// parse HH:MM time-of-day into time.Time on today's date
+func parseWindowBoundary(hhmm string, now time.Time) (*time.Time, error) {
+	if !rotateWindowRegexp.MatchString(hhmm) {
+		return nil, fmt.Errorf("must be in HH:MM format: %s", hhmm)
+	}
+	tokens := strings.SplitN(hhmm, ":", 2)
+	hh, mm := tokens[0], tokens[1]
+	hour, err := strconv.Atoi(hh)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse hour: %s", hh)
+	}
+	minute, err := strconv.Atoi(mm)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse minute: %s", mm)
+	}
+
+	t := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
+	return &t, nil
 }

--- a/cmd/yale/main.go
+++ b/cmd/yale/main.go
@@ -101,11 +101,17 @@ func parseRotateWindow(args *args, now time.Time) (*yale.RotateWindow, error) {
 		return nil, fmt.Errorf("-window-end: %v", err)
 	}
 
-	return &yale.RotateWindow{
+	window := &yale.RotateWindow{
 		Enabled:   true,
 		StartTime: *start,
 		EndTime:   *end,
-	}, nil
+	}
+
+	if window.StartTime.After(window.EndTime) {
+		return nil, fmt.Errorf("-window-start must be before -window-end: %s, %s", args.windowStart, args.windowEnd)
+	}
+
+	return window, nil
 }
 
 var rotateWindowRegexp = regexp.MustCompile("^[0-9]{2}:[0-9]{2}$")
@@ -121,9 +127,16 @@ func parseWindowBoundary(hhmm string, now time.Time) (*time.Time, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse hour: %s", hh)
 	}
+	if hour < 0 || hour > 23 {
+		return nil, fmt.Errorf("hour must be between 0 and 23: %s", hh)
+	}
+
 	minute, err := strconv.Atoi(mm)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse minute: %s", mm)
+	}
+	if minute < 0 || minute > 59 {
+		return nil, fmt.Errorf("minute must be between 0 and 59: %s", mm)
 	}
 
 	t := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())

--- a/cmd/yale/main_test.go
+++ b/cmd/yale/main_test.go
@@ -1,7 +1,108 @@
 package main
 
-import "testing"
+import (
+	"github.com/broadinstitute/yale/internal/yale"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
 
-func TestYale(t *testing.T) {
-	t.Skip("TODO")
+const layout = "2006-01-02T15:04:05Z"
+
+func Test_parseRotateWindow(t *testing.T) {
+	now := parseTimeOrPanic("2023-07-31T09:11:22Z")
+
+	testCases := []struct {
+		name      string
+		start     string
+		end       string
+		expectErr string
+		expected  *yale.RotateWindow
+	}{
+		{
+			name:     "neither flag set",
+			expected: &yale.RotateWindow{},
+		},
+		{
+			name:      "-window-start flag set",
+			start:     "11:22",
+			expectErr: "-window-start requires -window-end",
+		},
+		{
+			name:      "-window-end flag set",
+			end:       "11:22",
+			expectErr: "-window-end requires -window-start",
+		},
+		{
+			name:      "-window-end flag invalid",
+			start:     "11:22",
+			end:       "foo",
+			expectErr: "-window-end: must be in HH:MM format",
+		},
+		{
+			name:      "-window-start flag invalid",
+			start:     "11 :22",
+			end:       "13:01",
+			expectErr: "-window-start: must be in HH:MM format",
+		},
+		{
+			name:      "-window-start flag bad HH",
+			start:     "99:22",
+			end:       "13:01",
+			expectErr: "-window-start: hour must be between 0 and 23",
+		},
+		{
+			name:      "-window-start flag bad MM",
+			start:     "07:22",
+			end:       "13:99",
+			expectErr: "-window-end: minute must be between 0 and 59",
+		},
+		{
+			name:      "start after end",
+			start:     "13:22",
+			end:       "12:01",
+			expectErr: "-window-start must be before -window-end",
+		},
+		{
+			name:  "correct parsing",
+			start: "07:34",
+			end:   "15:01",
+			expected: &yale.RotateWindow{
+				Enabled:   true,
+				StartTime: parseTimeOrPanic("2023-07-31T07:34:00Z"),
+				EndTime:   parseTimeOrPanic("2023-07-31T15:01:00Z"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := &args{}
+
+			if tc.start != "" {
+				args.windowStart = tc.start
+			}
+			if tc.end != "" {
+				args.windowEnd = tc.end
+			}
+
+			window, err := parseRotateWindow(args, now)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+
+			assert.Equal(t, tc.expected, window)
+		})
+	}
+}
+
+func parseTimeOrPanic(value string) time.Time {
+	t, err := time.Parse(layout, value)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }

--- a/internal/tools/linter/linter.go
+++ b/internal/tools/linter/linter.go
@@ -136,7 +136,6 @@ func scan[T any](r resource[T], secrets []secret) []reference {
 				continue
 			}
 			logs.Info.Printf("%s: WILL NOT reload on changes", ref.summarize())
-			fmt.Println("why this is not working?")
 			if ignore.ignoresSecret(s.name) {
 				logs.Info.Printf("%s: ignoring missing reloader annotation", ref.summarize())
 				continue

--- a/internal/tools/linter/linter_test.go
+++ b/internal/tools/linter/linter_test.go
@@ -104,6 +104,9 @@ func Test_Linter(t *testing.T) {
 		{
 			name: "simple-missing-with-ignore",
 		},
+		{
+			name: "sts-missing-with-ignore",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/tools/linter/testdata/sts-missing-with-ignore/gsk.yaml
+++ b/internal/tools/linter/testdata/sts-missing-with-ignore/gsk.yaml
@@ -1,0 +1,7 @@
+apiVersion: yale.broadinstitute.org/v1beta1
+kind: GcpSaKey
+metadata:
+  name: gsk-1
+spec:
+  secret:
+    name: gsk-1-secret

--- a/internal/tools/linter/testdata/sts-missing-with-ignore/sts.yaml
+++ b/internal/tools/linter/testdata/sts-missing-with-ignore/sts.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Statefulset
+metadata:
+  name: sts-1
+  annotations:
+    yale.terra.bio/linter-ignore: all
+spec:
+  template:
+    spec:
+      containers:
+      - name: sts-1
+        envFrom:
+          - secretRef:
+              name: gsk-1-secret

--- a/internal/yale/yale_test.go
+++ b/internal/yale/yale_test.go
@@ -373,7 +373,7 @@ func (suite *YaleSuite) TestYaleIssuesNewSecretButDoesNotRotateIfOutsideRotation
 			IgnoreUsageMetrics: false,
 			RotateWindow: RotateWindow{
 				Enabled:   true,
-				StartTime: currentTime().Add(time.Hour),
+				StartTime: currentTime().Add(1 * time.Hour),
 				EndTime:   currentTime().Add(2 * time.Hour),
 			},
 		},

--- a/internal/yale/yale_test.go
+++ b/internal/yale/yale_test.go
@@ -87,6 +87,12 @@ func (suite *YaleSuite) SetupTest() {
 		Options{
 			CacheNamespace:     cache.DefaultCacheNamespace,
 			IgnoreUsageMetrics: false,
+			RotateWindow: RotateWindow{
+				Enabled: true,
+				// Make sure the current time is inside the rotation window
+				StartTime: currentTime().Add(-1 * time.Hour),
+				EndTime:   currentTime().Add(time.Hour),
+			},
 		},
 		suite.cache,
 		suite.resourcemapper,
@@ -342,6 +348,63 @@ func (suite *YaleSuite) TestYaleIssuesNewKeyForNewGcpSaKey() {
 	require.NoError(suite.T(), suite.yale.Run())
 
 	// make sure the cache contains the new key
+	entry, err := suite.cache.GetOrCreate(sa1)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), sa1key1.id, entry.CurrentKey.ID)
+	assert.Equal(suite.T(), sa1key1.json(), entry.CurrentKey.JSON)
+	suite.assertNow(entry.CurrentKey.CreatedAt)
+
+	// make sure the new key was replicated to the secret in the gsk spec
+	suite.assertSecretHasData("ns-1", "s1-secret", map[string]string{
+		"key.pem":  sa1key1.pem,
+		"key.json": sa1key1.json(),
+	})
+}
+
+func (suite *YaleSuite) TestYaleIssuesNewSecretButDoesNotRotateIfOutsideRotationWindow() {
+	_keyops := make(map[string]keyops.KeyOps)
+	// use mock implementations for both keyops instances
+	_keyops[gcpKeyops] = suite.keyops
+	_keyops[azureKeyops] = suite.keyops
+
+	suite.yale = newYaleFromComponents(
+		Options{
+			CacheNamespace:     cache.DefaultCacheNamespace,
+			IgnoreUsageMetrics: false,
+			RotateWindow: RotateWindow{
+				Enabled:   true,
+				StartTime: currentTime().Add(time.Hour),
+				EndTime:   currentTime().Add(2 * time.Hour),
+			},
+		},
+		suite.cache,
+		suite.resourcemapper,
+		suite.authmetrics,
+		_keyops,
+		suite.keysync,
+		suite.slack,
+	)
+
+	suite.seedGsks(gsk1, gsk2)
+	suite.seedAzureClientSecrets()
+
+	suite.seedCacheEntries(&cache.Entry{
+		Identifier: sa2,
+		Type:       cache.GcpSaKey,
+		CurrentKey: cache.CurrentKey{
+			ID:        sa2key1.id,
+			JSON:      sa2key1.json(),
+			CreatedAt: eightDaysAgo,
+		},
+	})
+
+	suite.expectCreateKey(sa1key1)
+
+	// Note: we do NOT expect a create key operation for sa2 because it is outside the rotation window
+
+	require.NoError(suite.T(), suite.yale.Run())
+
+	// make sure the cache contains the new key for sa1
 	entry, err := suite.cache.GetOrCreate(sa1)
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), sa1key1.id, entry.CurrentKey.ID)
@@ -1063,26 +1126,26 @@ func (suite *YaleSuite) TestYaleAggregatesAndReportsErrors() {
 	// make sure the cache entries for s1 and s3 have error information
 	entry, err = suite.cache.GetOrCreate(sa1)
 	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "error issuing new secret for s1@p.com: uh-oh", entry.LastError.Message)
+	assert.Equal(suite.T(), "GcpSaKey s1@p.com: error issuing new secret: error issuing new secret for s1@p.com: uh-oh", entry.LastError.Message)
 	suite.assertNow(entry.LastError.Timestamp)
 	suite.assertNow(entry.LastError.LastNotificationAt)
 
 	entryAcs, err = suite.cache.GetOrCreate(clientSecret1)
 	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "error issuing new secret for test-app-id-1: uh-oh", entryAcs.LastError.Message)
+	assert.Equal(suite.T(), "AzureClientSecret test-app-id-1: error issuing new secret: error issuing new secret for test-app-id-1: uh-oh", entryAcs.LastError.Message)
 	suite.assertNow(entryAcs.LastError.Timestamp)
 	suite.assertNow(entryAcs.LastError.LastNotificationAt)
 
 	// s3 should NOT have sent an error, because it was already sent recently
 	entry, err = suite.cache.GetOrCreate(sa3)
 	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "error issuing new secret for s3@p.com: oh noes", entry.LastError.Message)
+	assert.Equal(suite.T(), "GcpSaKey s3@p.com: error issuing new secret: error issuing new secret for s3@p.com: oh noes", entry.LastError.Message)
 	suite.assertNow(entry.LastError.Timestamp)
 	assert.Equal(suite.T(), lastNotification, entry.LastError.LastNotificationAt)
 
 	entryAcs, err = suite.cache.GetOrCreate(clientSecret3)
 	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "error issuing new secret for test-app-id-3: oh noes", entryAcs.LastError.Message)
+	assert.Equal(suite.T(), "AzureClientSecret test-app-id-3: error issuing new secret: error issuing new secret for test-app-id-3: oh noes", entryAcs.LastError.Message)
 	suite.assertNow(entryAcs.LastError.Timestamp)
 	assert.Equal(suite.T(), lastNotification, entryAcs.LastError.LastNotificationAt)
 


### PR DESCRIPTION
Add new flags to yale, `-window-start=HH:MM` and `-window-end=HH:MM`, that indicate a window per day during which Yale can perform key rotation operations.

### Motivation

When Yale rotates a key in broad-dsde-qa, it triggers a restart of all BEEs at once. This can be quite disruptive to developers and tests running in CI. Therefore we would like to configure key rotations for off-hours.

### Testing

This PR includes unit tests.