### PR TITLE
[DDO-3718] Add `owned_by: yale` label to all GSM secrets that Yale creates

### DIFF
--- a/internal/yale/keysync/keysync.go
+++ b/internal/yale/keysync/keysync.go
@@ -353,6 +353,9 @@ func (k *keysync) replicateKeyToGSM(entry *cache.Entry, syncable Syncable) error
 					Annotations: map[string]string{
 						"created-by-yale": "true",
 					},
+					Labels: map[string]string{
+						"owned_by": "yale",
+					},
 					Replication: &secretmanagerpb.Replication{
 						Replication: &secretmanagerpb.Replication_Automatic_{
 							Automatic: &secretmanagerpb.Replication_Automatic{},

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -811,7 +811,7 @@ func (suite *KeySyncSuite) expectGSMReplication(project string, secret string, p
 	suite.gsmServer.ExpectListSecretWithNameFilter(project, secret, nil)
 	suite.gsmServer.ExpectCreateNewSecret(project, secret, func(s *secretmanagerpb.Secret) bool {
 		require.Equal(suite.T(), map[string]string{"created-by-yale": "true"}, s.Annotations)
-		require.Equal(suite.T(), map[string]string{"managed_by": "yale"}, s.Labels)
+		require.Equal(suite.T(), map[string]string{"owned_by": "yale"}, s.Labels)
 		return true
 	}, &secretmanagerpb.Secret{
 		Name: "ignored",

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -811,6 +811,7 @@ func (suite *KeySyncSuite) expectGSMReplication(project string, secret string, p
 	suite.gsmServer.ExpectListSecretWithNameFilter(project, secret, nil)
 	suite.gsmServer.ExpectCreateNewSecret(project, secret, func(s *secretmanagerpb.Secret) bool {
 		require.Equal(suite.T(), map[string]string{"created-by-yale": "true"}, s.Annotations)
+		require.Equal(suite.T(), map[string]string{"managed_by": "yale"}, s.Labels)
 		return true
 	}, &secretmanagerpb.Secret{
 		Name: "ignored",


### PR DESCRIPTION
Per request from the Vault pod. This will take effect for all GSM secrets that Yale creates going forward, but not existing secrets.