### PR TITLE
DDO-3773 Fix Handling of Disabled State for Azure Client Secrets

### DIFF
--- a/internal/yale/keyops/azurekeyops/azurekeyops_test.go
+++ b/internal/yale/keyops/azurekeyops/azurekeyops_test.go
@@ -71,32 +71,10 @@ func Test_CreateErrorsIfResponseLacksSecret(t *testing.T) {
 	assert.ErrorContains(t, err, "secretText field was nil")
 }
 
-var notDisabledTime = time.Now().Add(time.Hour * 24)
 var testKey = keyops.Key{
 	Scope:      testTenantID,
 	Identifier: testApplicationID,
 	ID:         testKeyID,
-}
-
-func Test_isDisabledFalse(t *testing.T) {
-	keyops := setup(t, func(expect msgraphmock.Expect) {
-		expect.Get(context.Background(), testApplicationID, odata.Query{}).
-			Returns(&msgraph.Application{
-				AppId: &testApplicationID,
-				PasswordCredentials: &[]msgraph.PasswordCredential{
-					{
-						DisplayName: &testApplicationID,
-						KeyId:       &testKeyID,
-						SecretText:  &testSecret,
-						EndDateTime: &notDisabledTime,
-					},
-				},
-			})
-	})
-
-	disabled, err := keyops.IsDisabled(testKey)
-	require.NoError(t, err)
-	assert.False(t, disabled)
 }
 
 var expiredTime = time.Now().Add(time.Hour * -24)
@@ -141,26 +119,6 @@ func Test_deleteIfDisabled(t *testing.T) {
 
 	err := keyops.DeleteIfDisabled(testKey)
 	require.NoError(t, err)
-}
-
-func Test_dontDeleteIfNotDisabled(t *testing.T) {
-	keyops := setup(t, func(expect msgraphmock.Expect) {
-		expect.Get(context.Background(), testApplicationID, odata.Query{}).
-			Returns(&msgraph.Application{
-				AppId: &testApplicationID,
-				PasswordCredentials: &[]msgraph.PasswordCredential{
-					{
-						DisplayName: &testApplicationID,
-						KeyId:       &testKeyID,
-						SecretText:  &testSecret,
-						EndDateTime: &notDisabledTime,
-					},
-				},
-			})
-	})
-
-	err := keyops.DeleteIfDisabled(testKey)
-	require.ErrorContains(t, err, "is not disabled, cannot delete")
 }
 
 func setup(t *testing.T, expectFn func(msgraphmock.Expect)) keyops.KeyOps {

--- a/internal/yale/keyops/azurekeyops/azurekeyops_test.go
+++ b/internal/yale/keyops/azurekeyops/azurekeyops_test.go
@@ -100,6 +100,20 @@ func Test_isDisabledTrue(t *testing.T) {
 
 }
 
+func Test_disableNonExistentKey(t *testing.T) {
+	keyops := setup(t, func(expect msgraphmock.Expect) {
+		expect.Get(context.Background(), testApplicationID, odata.Query{}).
+			Returns(&msgraph.Application{
+				AppId:               &testApplicationID,
+				PasswordCredentials: &[]msgraph.PasswordCredential{},
+			})
+	})
+
+	_, err := keyops.IsDisabled(testKey)
+	require.ErrorContains(t, err, "error retrieving client secret info for application")
+
+}
+
 func Test_deleteIfDisabled(t *testing.T) {
 	keyops := setup(t, func(expect msgraphmock.Expect) {
 		expect.Get(context.Background(), testApplicationID, odata.Query{}).


### PR DESCRIPTION
Previously the handling for the disabled state of Azure Client Secrets was not correct. Azure client secrets do not have a concept of a disabled state like GCP service accounts do. To approximate this so that yale could still transition `AzureClientSecrets` through the various different states in its cache it would look at if they client secret existed and if it had expired to determine the result of whether a client secret is disabled or not. 

However this is incorrect behavior as unlike GCP SA keys all azure clients have an expiration, however that expiration is silently created when the key is created and is set to 2 years from the creation date by default. 

This would result in Yale saying that a AzureClientSecret is not disable until it is 2 years old which is obviously not what we want. This changes the azure key operations so that as long as a client secret id exists it will be considered disabled for the purposes of Yale's disabled checks. Yale's cutoffs for actually disabling/deleting the secret still apply here, so we don't have to worry about premature deletes. This essentially just makes it possible for yale to consider an azure client secret to be disabled even though that is effectively a no-op.

I am also removing tests here but they are around testing validity of expiration dates on the azure client secrets which is no longer relevant given the above. I also added a test case for trying to call `IsDisabled` for a non-existent key. Which is the only scenario where it should return  false and an error

