### PR TITLE
[DDO-3897] Dependabot secrets replication

### DIFF
--- a/internal/tools/linter/linter.go
+++ b/internal/tools/linter/linter.go
@@ -39,6 +39,8 @@ type document struct {
 	filename string
 }
 
+// in:#terra-asset-management after:2024-10-11 -cert -zebrafish -events -volumeattachments -customresourcedefinitions
+
 func Run(globs ...string) ([]reference, error) {
 	parser, err := newParser()
 	if err != nil {

--- a/internal/tools/linter/linter.go
+++ b/internal/tools/linter/linter.go
@@ -3,6 +3,7 @@ package linter
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"github.com/broadinstitute/yale/internal/yale/crd/api/v1beta1"
 	"github.com/broadinstitute/yale/internal/yale/logs"
@@ -69,7 +70,7 @@ func Run(globs ...string) ([]reference, error) {
 	for _, m := range matches {
 		msg = msg + "    " + m.summarize() + "\n"
 	}
-	return matches, fmt.Errorf(msg)
+	return matches, errors.New(msg)
 }
 
 func scanDir(parser *parser, dir string) ([]reference, error) {

--- a/internal/yale/crd/api/v1beta1/types.go
+++ b/internal/yale/crd/api/v1beta1/types.go
@@ -57,10 +57,10 @@ type GoogleSecretManagerReplication struct {
 }
 
 type GitHubReplication struct {
-	Secret     string            `json:"secret"`
-	Repo       string            `json:"repo"`
-	Format     ReplicationFormat `json:"format"`
-	SecretKind string            `json:"secretKind"`
+	Secret               string            `json:"secret"`
+	Repo                 string            `json:"repo"`
+	Format               ReplicationFormat `json:"format"`
+	RequiredByDependabot bool              `json:"requiredByDependabot"` // if supplied, also replicate to Dependabot secrets
 }
 
 type ReplicationFormat int64

--- a/internal/yale/crd/api/v1beta1/types.go
+++ b/internal/yale/crd/api/v1beta1/types.go
@@ -57,9 +57,10 @@ type GoogleSecretManagerReplication struct {
 }
 
 type GitHubReplication struct {
-	Secret string            `json:"secret"`
-	Repo   string            `json:"repo"`
-	Format ReplicationFormat `json:"format"`
+	Secret     string            `json:"secret"`
+	Repo       string            `json:"repo"`
+	Format     ReplicationFormat `json:"format"`
+	SecretKind string            `json:"secretKind"`
 }
 
 type ReplicationFormat int64

--- a/internal/yale/crd/api/v1beta1/types_test.go
+++ b/internal/yale/crd/api/v1beta1/types_test.go
@@ -124,10 +124,10 @@ func Test_GoogleSecretManagerReplicationSerialization(t *testing.T) {
 
 func Test_GitHubReplicationSerialization(t *testing.T) {
 	v := GitHubReplication{
-		Secret: "MY_SECRET",
-		Repo:   "my-org/my-repo",
-		Format: JSON,
-		Kind:   "dependabot",
+		Secret:     "MY_SECRET",
+		Repo:       "my-org/my-repo",
+		Format:     JSON,
+		SecretKind: "dependabot",
 	}
 
 	var err error

--- a/internal/yale/crd/api/v1beta1/types_test.go
+++ b/internal/yale/crd/api/v1beta1/types_test.go
@@ -124,10 +124,10 @@ func Test_GoogleSecretManagerReplicationSerialization(t *testing.T) {
 
 func Test_GitHubReplicationSerialization(t *testing.T) {
 	v := GitHubReplication{
-		Secret:     "MY_SECRET",
-		Repo:       "my-org/my-repo",
-		Format:     JSON,
-		SecretKind: "dependabot",
+		Secret:               "MY_SECRET",
+		Repo:                 "my-org/my-repo",
+		Format:               JSON,
+		RequiredByDependabot: true,
 	}
 
 	var err error

--- a/internal/yale/crd/api/v1beta1/types_test.go
+++ b/internal/yale/crd/api/v1beta1/types_test.go
@@ -127,6 +127,7 @@ func Test_GitHubReplicationSerialization(t *testing.T) {
 		Secret: "MY_SECRET",
 		Repo:   "my-org/my-repo",
 		Format: JSON,
+		Kind:   "dependabot",
 	}
 
 	var err error

--- a/internal/yale/keysync/github/client.go
+++ b/internal/yale/keysync/github/client.go
@@ -14,14 +14,14 @@ func NewClient(c *github.Client) Client {
 }
 
 type Client interface {
-	WriteSecret(owner string, repo string, secretName string, secretType string, content []byte) error
+	WriteSecret(owner string, repo string, secretName string, requiredByDependabot bool, content []byte) error
 }
 
 type client struct {
 	github *github.Client
 }
 
-func (c *client) WriteSecret(owner string, repo string, secretName string, secretType string, content []byte) error {
+func (c *client) WriteSecret(owner string, repo string, secretName string, requiredByDependabot bool, content []byte) error {
 	pubkey, _, err := c.github.Actions.GetRepoPublicKey(context.Background(), owner, repo)
 	if err != nil {
 		return fmt.Errorf("error retrieving public key for %s/%s: %v", owner, repo, err)
@@ -32,26 +32,27 @@ func (c *client) WriteSecret(owner string, repo string, secretName string, secre
 		return fmt.Errorf("error encrypting secret for %s/%s: %v", owner, repo, err)
 	}
 
-	logs.Info.Printf("Writing to GitHub secret %s in repo %s/%s", secretName, owner, repo)
+	logs.Info.Printf("Writing to GitHub Actions secret %s in repo %s/%s", secretName, owner, repo)
+	_, err = c.github.Actions.CreateOrUpdateRepoSecret(context.Background(), owner, repo, &github.EncryptedSecret{
+		Name:           secretName,
+		KeyID:          *pubkey.KeyID,
+		EncryptedValue: encryptedSecret,
+	})
+	if err != nil {
+		return fmt.Errorf("error pushing encrypted GitHub Actions secret %s %s/%s: %v", secretName, owner, repo, err)
+	}
 
-	switch secretType {
-	case "actions":
-		_, err = c.github.Actions.CreateOrUpdateRepoSecret(context.Background(), owner, repo, &github.EncryptedSecret{
-			Name:           secretName,
-			KeyID:          *pubkey.KeyID,
-			EncryptedValue: encryptedSecret,
-		})
-	case "dependabot":
+	if requiredByDependabot {
+		logs.Info.Printf("Writing to GitHub Dependabot secret %s in repo %s/%s", secretName, owner, repo)
 		_, err = c.github.Dependabot.CreateOrUpdateRepoSecret(context.Background(), owner, repo, &github.DependabotEncryptedSecret{
 			Name:           secretName,
 			KeyID:          *pubkey.KeyID,
 			EncryptedValue: encryptedSecret,
 		})
-	default:
-		return fmt.Errorf("error replicating secret for %s/%s: uknown GitHub secret type %s", owner, repo, secretType)
+		if err != nil {
+			return fmt.Errorf("error pushing encrypted GitHub Actions secret %s %s/%s: %v", secretName, owner, repo, err)
+		}
 	}
-	if err != nil {
-		return fmt.Errorf("error pushing encrypted GitHub secret %s (type %s) to %s/%s: %v", secretName, secretType, owner, repo, err)
-	}
+
 	return nil
 }

--- a/internal/yale/keysync/github/client.go
+++ b/internal/yale/keysync/github/client.go
@@ -43,7 +43,7 @@ func (c *client) WriteSecret(owner string, repo string, secretName string, requi
 	}
 
 	if requiredByDependabot {
-		pubkey, _, err = c.github.Actions.GetRepoPublicKey(context.Background(), owner, repo)
+		pubkey, _, err = c.github.Dependabot.GetRepoPublicKey(context.Background(), owner, repo)
 		if err != nil {
 			return fmt.Errorf("error retrieving dependabot public key for %s/%s: %v", owner, repo, err)
 		}

--- a/internal/yale/keysync/github/client.go
+++ b/internal/yale/keysync/github/client.go
@@ -14,14 +14,14 @@ func NewClient(c *github.Client) Client {
 }
 
 type Client interface {
-	WriteSecret(owner string, repo string, secretName string, content []byte) error
+	WriteSecret(owner string, repo string, secretName string, secretType string, content []byte) error
 }
 
 type client struct {
 	github *github.Client
 }
 
-func (c *client) WriteSecret(owner string, repo string, secretName string, content []byte) error {
+func (c *client) WriteSecret(owner string, repo string, secretName string, secretType string, content []byte) error {
 	pubkey, _, err := c.github.Actions.GetRepoPublicKey(context.Background(), owner, repo)
 	if err != nil {
 		return fmt.Errorf("error retrieving public key for %s/%s: %v", owner, repo, err)
@@ -34,13 +34,24 @@ func (c *client) WriteSecret(owner string, repo string, secretName string, conte
 
 	logs.Info.Printf("Writing to GitHub secret %s in repo %s/%s", secretName, owner, repo)
 
-	_, err = c.github.Actions.CreateOrUpdateRepoSecret(context.Background(), owner, repo, &github.EncryptedSecret{
-		Name:           secretName,
-		KeyID:          *pubkey.KeyID,
-		EncryptedValue: encryptedSecret,
-	})
+	switch secretType {
+	case "actions":
+		_, err = c.github.Actions.CreateOrUpdateRepoSecret(context.Background(), owner, repo, &github.EncryptedSecret{
+			Name:           secretName,
+			KeyID:          *pubkey.KeyID,
+			EncryptedValue: encryptedSecret,
+		})
+	case "dependabot":
+		_, err = c.github.Dependabot.CreateOrUpdateRepoSecret(context.Background(), owner, repo, &github.DependabotEncryptedSecret{
+			Name:           secretName,
+			KeyID:          *pubkey.KeyID,
+			EncryptedValue: encryptedSecret,
+		})
+	default:
+		return fmt.Errorf("error replicating secret for %s/%s: uknown GitHub secret type %s", owner, repo, secretType)
+	}
 	if err != nil {
-		return fmt.Errorf("error pushing encrypted GitHub secret %s to %s/%s: %v", secretName, owner, repo, err)
+		return fmt.Errorf("error pushing encrypted GitHub secret %s (type %s) to %s/%s: %v", secretName, secretType, owner, repo, err)
 	}
 	return nil
 }

--- a/internal/yale/keysync/github/client_test.go
+++ b/internal/yale/keysync/github/client_test.go
@@ -22,7 +22,7 @@ func Test_Client_WritesSecret(t *testing.T) {
 
 	r, err := recorder.NewWithOptions(&recorder.Options{
 		CassetteName:       "testdata/fixtures/client_test",
-		Mode:               recorder.ModeRecordOnce, // change or delete fixture to re-record
+		Mode:               recorder.ModeRecordOnce, // delete fixture to re-record
 		SkipRequestLatency: true,
 	})
 	require.NoError(t, err)
@@ -44,5 +44,5 @@ func Test_Client_WritesSecret(t *testing.T) {
 	_client := NewClient(githubClient)
 
 	// write the secret
-	require.NoError(t, _client.WriteSecret(repo, org, secretName, false, []byte("some data")))
+	require.NoError(t, _client.WriteSecret(repo, org, secretName, true, []byte("some data")))
 }

--- a/internal/yale/keysync/github/client_test.go
+++ b/internal/yale/keysync/github/client_test.go
@@ -44,5 +44,5 @@ func Test_Client_WritesSecret(t *testing.T) {
 	_client := NewClient(githubClient)
 
 	// write the secret
-	require.NoError(t, _client.WriteSecret(repo, org, secretName, "actions", []byte("some data")))
+	require.NoError(t, _client.WriteSecret(repo, org, secretName, false, []byte("some data")))
 }

--- a/internal/yale/keysync/github/client_test.go
+++ b/internal/yale/keysync/github/client_test.go
@@ -44,5 +44,5 @@ func Test_Client_WritesSecret(t *testing.T) {
 	_client := NewClient(githubClient)
 
 	// write the secret
-	require.NoError(t, _client.WriteSecret(repo, org, secretName, []byte("some data")))
+	require.NoError(t, _client.WriteSecret(repo, org, secretName, "actions", []byte("some data")))
 }

--- a/internal/yale/keysync/github/mocks/client.go
+++ b/internal/yale/keysync/github/mocks/client.go
@@ -17,17 +17,17 @@ func (_m *Client) EXPECT() *Client_Expecter {
 	return &Client_Expecter{mock: &_m.Mock}
 }
 
-// WriteSecret provides a mock function with given fields: owner, repo, secretName, secretType, content
-func (_m *Client) WriteSecret(owner string, repo string, secretName string, secretType string, content []byte) error {
-	ret := _m.Called(owner, repo, secretName, secretType, content)
+// WriteSecret provides a mock function with given fields: owner, repo, secretName, requiredByDependabot, content
+func (_m *Client) WriteSecret(owner string, repo string, secretName string, requiredByDependabot bool, content []byte) error {
+	ret := _m.Called(owner, repo, secretName, requiredByDependabot, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for WriteSecret")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, []byte) error); ok {
-		r0 = rf(owner, repo, secretName, secretType, content)
+	if rf, ok := ret.Get(0).(func(string, string, string, bool, []byte) error); ok {
+		r0 = rf(owner, repo, secretName, requiredByDependabot, content)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -44,15 +44,15 @@ type Client_WriteSecret_Call struct {
 //   - owner string
 //   - repo string
 //   - secretName string
-//   - secretType string
+//   - requiredByDependabot bool
 //   - content []byte
-func (_e *Client_Expecter) WriteSecret(owner interface{}, repo interface{}, secretName interface{}, secretType interface{}, content interface{}) *Client_WriteSecret_Call {
-	return &Client_WriteSecret_Call{Call: _e.mock.On("WriteSecret", owner, repo, secretName, secretType, content)}
+func (_e *Client_Expecter) WriteSecret(owner interface{}, repo interface{}, secretName interface{}, requiredByDependabot interface{}, content interface{}) *Client_WriteSecret_Call {
+	return &Client_WriteSecret_Call{Call: _e.mock.On("WriteSecret", owner, repo, secretName, requiredByDependabot, content)}
 }
 
-func (_c *Client_WriteSecret_Call) Run(run func(owner string, repo string, secretName string, secretType string, content []byte)) *Client_WriteSecret_Call {
+func (_c *Client_WriteSecret_Call) Run(run func(owner string, repo string, secretName string, requiredByDependabot bool, content []byte)) *Client_WriteSecret_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].([]byte))
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(bool), args[4].([]byte))
 	})
 	return _c
 }
@@ -62,7 +62,7 @@ func (_c *Client_WriteSecret_Call) Return(_a0 error) *Client_WriteSecret_Call {
 	return _c
 }
 
-func (_c *Client_WriteSecret_Call) RunAndReturn(run func(string, string, string, string, []byte) error) *Client_WriteSecret_Call {
+func (_c *Client_WriteSecret_Call) RunAndReturn(run func(string, string, string, bool, []byte) error) *Client_WriteSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/yale/keysync/github/mocks/client.go
+++ b/internal/yale/keysync/github/mocks/client.go
@@ -17,17 +17,17 @@ func (_m *Client) EXPECT() *Client_Expecter {
 	return &Client_Expecter{mock: &_m.Mock}
 }
 
-// WriteSecret provides a mock function with given fields: owner, repo, secretName, content
-func (_m *Client) WriteSecret(owner string, repo string, secretName string, content []byte) error {
-	ret := _m.Called(owner, repo, secretName, content)
+// WriteSecret provides a mock function with given fields: owner, repo, secretName, secretType, content
+func (_m *Client) WriteSecret(owner string, repo string, secretName string, secretType string, content []byte) error {
+	ret := _m.Called(owner, repo, secretName, secretType, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for WriteSecret")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, []byte) error); ok {
-		r0 = rf(owner, repo, secretName, content)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, []byte) error); ok {
+		r0 = rf(owner, repo, secretName, secretType, content)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -44,14 +44,15 @@ type Client_WriteSecret_Call struct {
 //   - owner string
 //   - repo string
 //   - secretName string
+//   - secretType string
 //   - content []byte
-func (_e *Client_Expecter) WriteSecret(owner interface{}, repo interface{}, secretName interface{}, content interface{}) *Client_WriteSecret_Call {
-	return &Client_WriteSecret_Call{Call: _e.mock.On("WriteSecret", owner, repo, secretName, content)}
+func (_e *Client_Expecter) WriteSecret(owner interface{}, repo interface{}, secretName interface{}, secretType interface{}, content interface{}) *Client_WriteSecret_Call {
+	return &Client_WriteSecret_Call{Call: _e.mock.On("WriteSecret", owner, repo, secretName, secretType, content)}
 }
 
-func (_c *Client_WriteSecret_Call) Run(run func(owner string, repo string, secretName string, content []byte)) *Client_WriteSecret_Call {
+func (_c *Client_WriteSecret_Call) Run(run func(owner string, repo string, secretName string, secretType string, content []byte)) *Client_WriteSecret_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].([]byte))
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].([]byte))
 	})
 	return _c
 }
@@ -61,7 +62,7 @@ func (_c *Client_WriteSecret_Call) Return(_a0 error) *Client_WriteSecret_Call {
 	return _c
 }
 
-func (_c *Client_WriteSecret_Call) RunAndReturn(run func(string, string, string, []byte) error) *Client_WriteSecret_Call {
+func (_c *Client_WriteSecret_Call) RunAndReturn(run func(string, string, string, string, []byte) error) *Client_WriteSecret_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/yale/keysync/github/testdata/fixtures/client_test.yaml
+++ b/internal/yale/keysync/github/testdata/fixtures/client_test.yaml
@@ -44,15 +44,15 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 28 Jun 2024 18:30:59 GMT
+                - Wed, 18 Dec 2024 16:16:18 GMT
             Etag:
-                - W/"9abedcb701ca81279dc155e9e1e4c73ec2372a0e316a1aaa611f93a4ddba5429"
+                - W/"e56de75d7b196f007436ffdc20c3d4193e8e5632bf0973b56f4f63be90b8b16f"
             Github-Authentication-Token-Expiration:
-                - 2024-07-05 18:23:27 UTC
+                - 2025-01-17 16:13:34 UTC
             Referrer-Policy:
                 - origin-when-cross-origin, strict-origin-when-cross-origin
             Server:
-                - istio-envoy
+                - github.com
             Strict-Transport-Security:
                 - max-age=31536000; includeSubdomains; preload
             Vary:
@@ -61,8 +61,6 @@ interactions:
                 - ""
             X-Content-Type-Options:
                 - nosniff
-            X-Envoy-Upstream-Service-Time:
-                - "53"
             X-Frame-Options:
                 - deny
             X-Github-Api-Version-Selected:
@@ -70,24 +68,24 @@ interactions:
             X-Github-Media-Type:
                 - github.v3; format=json
             X-Github-Request-Id:
-                - CC84:1A4FE5:C12FAE:1619573:667F0163
+                - E765:1A0A2D:54EB0A4:A83B877:6762F552
             X-Oauth-Scopes:
                 - repo
             X-Ratelimit-Limit:
                 - "5000"
             X-Ratelimit-Remaining:
-                - "4994"
+                - "4989"
             X-Ratelimit-Reset:
-                - "1719602599"
+                - "1734538994"
             X-Ratelimit-Resource:
                 - core
             X-Ratelimit-Used:
-                - "6"
+                - "11"
             X-Xss-Protection:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 150.929917ms
+        duration: 190.217542ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -100,7 +98,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"key_id":"3380204578043523366","encrypted_value":"bY6XmjboGreI8qvcoiy8n4n57BEfoG2pAsunXlnL03ssZfOPILBP0YiGMZk7g0D3K0HSA/g8kzHM"}
+            {"key_id":"3380204578043523366","encrypted_value":"i7i/K4J0CHR1/dcMMnUxK0Ecs0qm/qmD3/UquaCWR3YZ3RJgQsY1d879IJgjyXv3dR4cveYldYTL"}
         form: {}
         headers:
             Accept:
@@ -130,13 +128,13 @@ interactions:
             Content-Security-Policy:
                 - default-src 'none'
             Date:
-                - Fri, 28 Jun 2024 18:30:59 GMT
+                - Wed, 18 Dec 2024 16:16:19 GMT
             Github-Authentication-Token-Expiration:
-                - 2024-07-05 18:23:27 UTC
+                - 2025-01-17 16:13:34 UTC
             Referrer-Policy:
                 - origin-when-cross-origin, strict-origin-when-cross-origin
             Server:
-                - istio-envoy
+                - github.com
             Strict-Transport-Security:
                 - max-age=31536000; includeSubdomains; preload
             Vary:
@@ -145,8 +143,6 @@ interactions:
                 - ""
             X-Content-Type-Options:
                 - nosniff
-            X-Envoy-Upstream-Service-Time:
-                - "93"
             X-Frame-Options:
                 - deny
             X-Github-Api-Version-Selected:
@@ -154,21 +150,196 @@ interactions:
             X-Github-Media-Type:
                 - github.v3; format=json
             X-Github-Request-Id:
-                - CC84:1A4FE5:C12FF7:16195FA:667F0163
+                - E765:1A0A2D:54EB113:A83B986:6762F552
             X-Oauth-Scopes:
                 - repo
             X-Ratelimit-Limit:
                 - "5000"
             X-Ratelimit-Remaining:
-                - "4993"
+                - "4988"
             X-Ratelimit-Reset:
-                - "1719602599"
+                - "1734538994"
             X-Ratelimit-Resource:
                 - core
             X-Ratelimit-Used:
-                - "7"
+                - "12"
             X-Xss-Protection:
                 - "0"
         status: 204 No Content
         code: 204
-        duration: 118.410875ms
+        duration: 239.606917ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.github.v3+json
+            User-Agent:
+                - go-github/v62.0.0
+            X-Github-Api-Version:
+                - "2022-11-28"
+        url: https://api.github.com/repos/broadinstitute/yale/dependabot/secrets/public-key
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"key_id":"3380217566468950943","key":"ur5MEbtH3evT4d2bIXRh6M59EGMH5etfzpM10he8hBQ="}'
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
+            Cache-Control:
+                - private, max-age=60, s-maxage=60
+            Content-Security-Policy:
+                - default-src 'none'
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 18 Dec 2024 16:16:19 GMT
+            Etag:
+                - W/"9960b98443f33ed94434f836ae7b0de5919f3049cec1b53db53cb06890f47700"
+            Github-Authentication-Token-Expiration:
+                - 2025-01-17 16:13:34 UTC
+            Referrer-Policy:
+                - origin-when-cross-origin, strict-origin-when-cross-origin
+            Server:
+                - github.com
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubdomains; preload
+            Vary:
+                - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-Oauth-Scopes:
+                - ""
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - deny
+            X-Github-Api-Version-Selected:
+                - "2022-11-28"
+            X-Github-Media-Type:
+                - github.v3; format=json
+            X-Github-Request-Id:
+                - E765:1A0A2D:54EB208:A83BB35:6762F553
+            X-Oauth-Scopes:
+                - repo
+            X-Ratelimit-Limit:
+                - "5000"
+            X-Ratelimit-Remaining:
+                - "4987"
+            X-Ratelimit-Reset:
+                - "1734538994"
+            X-Ratelimit-Resource:
+                - core
+            X-Ratelimit-Used:
+                - "13"
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 99.278792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 130
+        transfer_encoding: []
+        trailer: {}
+        host: api.github.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"key_id":"3380217566468950943","encrypted_value":"pbGJIKy+8xmnspShrlfIFUYBwLmDeV4mdF86HX9yelPvlNtNAdA+oZ+nYuOOIgVC7xVRvwxc5kNJ"}
+        form: {}
+        headers:
+            Accept:
+                - application/vnd.github.v3+json
+            Content-Type:
+                - application/json
+            User-Agent:
+                - go-github/v62.0.0
+            X-Github-Api-Version:
+                - "2022-11-28"
+        url: https://api.github.com/repos/broadinstitute/yale/dependabot/secrets/MY_TEST_SECRET
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Expose-Headers:
+                - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
+            Cache-Control:
+                - private, max-age=60, s-maxage=60
+            Content-Length:
+                - "2"
+            Content-Security-Policy:
+                - default-src 'none'
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Wed, 18 Dec 2024 16:16:19 GMT
+            Etag:
+                - '"9e8c22466548b49c14dbe681e7ae46b950329e191a013303358d64d02a73d605"'
+            Github-Authentication-Token-Expiration:
+                - 2025-01-17 16:13:34 UTC
+            Referrer-Policy:
+                - origin-when-cross-origin, strict-origin-when-cross-origin
+            Server:
+                - github.com
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubdomains; preload
+            Vary:
+                - Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-Oauth-Scopes:
+                - ""
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - deny
+            X-Github-Api-Version-Selected:
+                - "2022-11-28"
+            X-Github-Media-Type:
+                - github.v3; format=json
+            X-Github-Request-Id:
+                - E765:1A0A2D:54EB266:A83BBF3:6762F553
+            X-Oauth-Scopes:
+                - repo
+            X-Ratelimit-Limit:
+                - "5000"
+            X-Ratelimit-Remaining:
+                - "4986"
+            X-Ratelimit-Reset:
+                - "1734538994"
+            X-Ratelimit-Resource:
+                - core
+            X-Ratelimit-Used:
+                - "14"
+            X-Xss-Protection:
+                - "0"
+        status: 201 Created
+        code: 201
+        duration: 187.715375ms

--- a/internal/yale/keysync/keysync.go
+++ b/internal/yale/keysync/keysync.go
@@ -482,9 +482,9 @@ func (k *keysync) replicateKeyToGitHub(entry *cache.Entry, syncable Syncable) er
 			return fmt.Errorf("%s/%s: error formatting secret for %s/%s: %v", syncable.Namespace(), syncable.Name(), org, repo, err)
 		}
 
-		logs.Info.Printf("Writing %s secret for %s/%s to GitHub secret %s in repo %s (format: %s)", r.SecretKind, syncable.Namespace(), syncable.Name(), r.Secret, r.Repo, r.Format)
+		logs.Info.Printf("Writing secret for %s/%s to GitHub secret %s in repo %s (format: %s)", syncable.Namespace(), syncable.Name(), r.Secret, r.Repo, r.Format)
 
-		err = k.github.WriteSecret(org, repo, r.Secret, r.SecretKind, formatted)
+		err = k.github.WriteSecret(org, repo, r.Secret, r.RequiredByDependabot, formatted)
 		if err != nil {
 			return fmt.Errorf("%s/%s: error writing GitHub secret %s in repo %s/%s: %v", syncable.Namespace(), syncable.Name(), r.Secret, org, repo, err)
 		}

--- a/internal/yale/keysync/keysync.go
+++ b/internal/yale/keysync/keysync.go
@@ -482,9 +482,9 @@ func (k *keysync) replicateKeyToGitHub(entry *cache.Entry, syncable Syncable) er
 			return fmt.Errorf("%s/%s: error formatting secret for %s/%s: %v", syncable.Namespace(), syncable.Name(), org, repo, err)
 		}
 
-		logs.Info.Printf("Writing secret for %s/%s to GitHub secret %s in repo %s (format: %s)", syncable.Namespace(), syncable.Name(), r.Secret, r.Repo, r.Format)
+		logs.Info.Printf("Writing %s secret for %s/%s to GitHub secret %s in repo %s (format: %s)", r.SecretKind, syncable.Namespace(), syncable.Name(), r.Secret, r.Repo, r.Format)
 
-		err = k.github.WriteSecret(org, repo, r.Secret, formatted)
+		err = k.github.WriteSecret(org, repo, r.Secret, r.SecretKind, formatted)
 		if err != nil {
 			return fmt.Errorf("%s/%s: error writing GitHub secret %s in repo %s/%s: %v", syncable.Namespace(), syncable.Name(), r.Secret, org, repo, err)
 		}

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -653,24 +653,28 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedGoogleSAKeyGitHubReplica
 			},
 			GitHubReplications: []apiv1b1.GitHubReplication{
 				{
-					Repo:   "my-org/my-repo",
-					Secret: "MY_SECRET_JSON",
-					Format: apiv1b1.JSON,
+					Repo:       "my-org/my-repo",
+					Secret:     "MY_SECRET_JSON",
+					Format:     apiv1b1.JSON,
+					SecretKind: "actions",
 				},
 				{
-					Repo:   "my-org/my-repo",
-					Secret: "MY_SECRET_PEM",
-					Format: apiv1b1.PEM,
+					Repo:       "my-org/my-repo",
+					Secret:     "MY_SECRET_PEM",
+					Format:     apiv1b1.PEM,
+					SecretKind: "dependabot",
 				},
 				{
-					Repo:   "my-org/my-repo",
-					Secret: "MY_SECRET_B64",
-					Format: apiv1b1.Base64,
+					Repo:       "my-org/my-repo",
+					Secret:     "MY_SECRET_B64",
+					Format:     apiv1b1.Base64,
+					SecretKind: "actions",
 				},
 				{
-					Repo:   "my-org/my-repo",
-					Secret: "MY_SECRET_PLAIN",
-					Format: apiv1b1.PlainText,
+					Repo:       "my-org/my-repo",
+					Secret:     "MY_SECRET_PLAIN",
+					Format:     apiv1b1.PlainText,
+					SecretKind: "dependabot",
 				},
 			},
 		},
@@ -678,10 +682,10 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedGoogleSAKeyGitHubReplica
 
 	suite.cache.EXPECT().Save(entry).Return(nil)
 
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_JSON", []byte(key1.json)).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PEM", []byte(key1.pem)).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", []byte(key1.base64)).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", []byte(key1.json)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_JSON", "actions", []byte(key1.json)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PEM", "dependabot", []byte(key1.pem)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", "actions", []byte(key1.base64)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", "dependabot", []byte(key1.json)).Return(nil)
 
 	// run a key sync to create the K8s secret and perform the vault replications
 	gsks := []apiv1b1.GcpSaKey{gsk}
@@ -720,14 +724,16 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubR
 			},
 			GitHubReplications: []apiv1b1.GitHubReplication{
 				{
-					Format: apiv1b1.PlainText,
-					Repo:   "my-org/my-repo",
-					Secret: "MY_SECRET_PLAIN",
+					Format:     apiv1b1.PlainText,
+					Repo:       "my-org/my-repo",
+					Secret:     "MY_SECRET_PLAIN",
+					SecretKind: "actions",
 				},
 				{
-					Format: apiv1b1.Base64,
-					Repo:   "my-org/my-repo",
-					Secret: "MY_SECRET_B64",
+					Format:     apiv1b1.Base64,
+					Repo:       "my-org/my-repo",
+					Secret:     "MY_SECRET_B64",
+					SecretKind: "dependabot",
 				},
 			},
 		},
@@ -735,8 +741,8 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubR
 
 	suite.cache.EXPECT().Save(entry).Return(nil)
 
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", []byte("my-acs-secret")).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", []byte("bXktYWNzLXNlY3JldA==")).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", "actions", []byte("my-acs-secret")).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", "dependabot", []byte("bXktYWNzLXNlY3JldA==")).Return(nil)
 
 	acsSecrets := []apiv1b1.AzureClientSecret{acs}
 	require.NoError(suite.T(), suite.keysync.SyncIfNeeded(entry, AzureClientSecretsToSyncable(acsSecrets)))

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -697,7 +697,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedGoogleSAKeyGitHubReplica
 
 	// make sure sync status was generated correctly
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "83b54b79f537b1fe4210bff6ffe127093ade36f9e7bc8a0f7ce66d0b6dd788fa:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "e906c9bf32bed8732bda333d568eeb6245988f92a209b3a077d8325b77c12699:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubReplications() {
@@ -751,7 +751,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubR
 	require.NoError(suite.T(), err)
 
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "fad90f6c6d9204b9b9a796b65cfb7f64b6843c2294430bbba355aa635fa9afc4:"+"1234-1234-1234", entry.SyncStatus["my-namespace/my-acs"])
+	assert.Equal(suite.T(), "a176cdedd1fdd294394494789474d4211266e3b00c1ccc9005fc9178cf920350:"+"1234-1234-1234", entry.SyncStatus["my-namespace/my-acs"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformGitHubReplicationsIfGitHubReplicationIsDisabled() {
@@ -803,7 +803,7 @@ func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformGitHubReplicationsIfGitHub
 
 	// make sure sync status was generated correctly
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "6b8ed4019d4e9b65e956f3deaf4bf1e1f30744f02b086950801d22fdb6949c15:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "7b8f2c0978d940d96b59252d1b5adfe888d352e01f6408dac2c59aed1e67903e:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 
 	// assert WriteSecret was not called
 	suite.githubClient.AssertNotCalled(suite.T(), "WriteSecret")

--- a/internal/yale/keysync/keysync_test.go
+++ b/internal/yale/keysync/keysync_test.go
@@ -653,28 +653,28 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedGoogleSAKeyGitHubReplica
 			},
 			GitHubReplications: []apiv1b1.GitHubReplication{
 				{
-					Repo:       "my-org/my-repo",
-					Secret:     "MY_SECRET_JSON",
-					Format:     apiv1b1.JSON,
-					SecretKind: "actions",
+					Repo:                 "my-org/my-repo",
+					Secret:               "MY_SECRET_JSON",
+					Format:               apiv1b1.JSON,
+					RequiredByDependabot: false,
 				},
 				{
-					Repo:       "my-org/my-repo",
-					Secret:     "MY_SECRET_PEM",
-					Format:     apiv1b1.PEM,
-					SecretKind: "dependabot",
+					Repo:                 "my-org/my-repo",
+					Secret:               "MY_SECRET_PEM",
+					Format:               apiv1b1.PEM,
+					RequiredByDependabot: true,
 				},
 				{
-					Repo:       "my-org/my-repo",
-					Secret:     "MY_SECRET_B64",
-					Format:     apiv1b1.Base64,
-					SecretKind: "actions",
+					Repo:                 "my-org/my-repo",
+					Secret:               "MY_SECRET_B64",
+					Format:               apiv1b1.Base64,
+					RequiredByDependabot: false,
 				},
 				{
-					Repo:       "my-org/my-repo",
-					Secret:     "MY_SECRET_PLAIN",
-					Format:     apiv1b1.PlainText,
-					SecretKind: "dependabot",
+					Repo:                 "my-org/my-repo",
+					Secret:               "MY_SECRET_PLAIN",
+					Format:               apiv1b1.PlainText,
+					RequiredByDependabot: true,
 				},
 			},
 		},
@@ -682,10 +682,10 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedGoogleSAKeyGitHubReplica
 
 	suite.cache.EXPECT().Save(entry).Return(nil)
 
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_JSON", "actions", []byte(key1.json)).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PEM", "dependabot", []byte(key1.pem)).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", "actions", []byte(key1.base64)).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", "dependabot", []byte(key1.json)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_JSON", false, []byte(key1.json)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PEM", true, []byte(key1.pem)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", false, []byte(key1.base64)).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", true, []byte(key1.json)).Return(nil)
 
 	// run a key sync to create the K8s secret and perform the vault replications
 	gsks := []apiv1b1.GcpSaKey{gsk}
@@ -697,7 +697,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedGoogleSAKeyGitHubReplica
 
 	// make sure sync status was generated correctly
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "e906c9bf32bed8732bda333d568eeb6245988f92a209b3a077d8325b77c12699:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "f61601398d7f36f86dee1a675409893348ae11a04fe1edf92b4001ead7a8a420:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubReplications() {
@@ -724,16 +724,16 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubR
 			},
 			GitHubReplications: []apiv1b1.GitHubReplication{
 				{
-					Format:     apiv1b1.PlainText,
-					Repo:       "my-org/my-repo",
-					Secret:     "MY_SECRET_PLAIN",
-					SecretKind: "actions",
+					Format:               apiv1b1.PlainText,
+					Repo:                 "my-org/my-repo",
+					Secret:               "MY_SECRET_PLAIN",
+					RequiredByDependabot: false,
 				},
 				{
-					Format:     apiv1b1.Base64,
-					Repo:       "my-org/my-repo",
-					Secret:     "MY_SECRET_B64",
-					SecretKind: "dependabot",
+					Format:               apiv1b1.Base64,
+					Repo:                 "my-org/my-repo",
+					Secret:               "MY_SECRET_B64",
+					RequiredByDependabot: true,
 				},
 			},
 		},
@@ -741,8 +741,8 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubR
 
 	suite.cache.EXPECT().Save(entry).Return(nil)
 
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", "actions", []byte("my-acs-secret")).Return(nil)
-	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", "dependabot", []byte("bXktYWNzLXNlY3JldA==")).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_PLAIN", false, []byte("my-acs-secret")).Return(nil)
+	suite.githubClient.EXPECT().WriteSecret("my-org", "my-repo", "MY_SECRET_B64", true, []byte("bXktYWNzLXNlY3JldA==")).Return(nil)
 
 	acsSecrets := []apiv1b1.AzureClientSecret{acs}
 	require.NoError(suite.T(), suite.keysync.SyncIfNeeded(entry, AzureClientSecretsToSyncable(acsSecrets)))
@@ -751,7 +751,7 @@ func (suite *KeySyncSuite) Test_KeySync_PerformsExpectedAzureClientSecretGitHubR
 	require.NoError(suite.T(), err)
 
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "a176cdedd1fdd294394494789474d4211266e3b00c1ccc9005fc9178cf920350:"+"1234-1234-1234", entry.SyncStatus["my-namespace/my-acs"])
+	assert.Equal(suite.T(), "ac500149626d314a35bfc3e32fa7f084b4f9ae6fa7599daee7b4faf3c59dbb69:"+"1234-1234-1234", entry.SyncStatus["my-namespace/my-acs"])
 }
 
 func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformGitHubReplicationsIfGitHubReplicationIsDisabled() {
@@ -803,7 +803,7 @@ func (suite *KeySyncSuite) Test_KeySync_DoesNotPerformGitHubReplicationsIfGitHub
 
 	// make sure sync status was generated correctly
 	assert.Len(suite.T(), entry.SyncStatus, 1)
-	assert.Equal(suite.T(), "7b8f2c0978d940d96b59252d1b5adfe888d352e01f6408dac2c59aed1e67903e:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
+	assert.Equal(suite.T(), "3955cb6660298a5602c46a52deecab44c54a080a19e8e63a6b1b77979e38494d:"+key1.id, entry.SyncStatus["my-namespace/my-gsk"])
 
 	// assert WriteSecret was not called
 	suite.githubClient.AssertNotCalled(suite.T(), "WriteSecret")


### PR DESCRIPTION
Currently Yale supports replication for Actions-type secrets, but the TDR team has a need for replication of Dependabot-type secrets as well. This PR adds that support, by adding a new `requiredByDependabot` boolean field to the CRD.

### Testing

This PR includes unit tests. I also manually verified that the changes were working in dev:
<img width="792" alt="Screenshot 2024-12-18 at 11 26 41 AM" src="https://github.com/user-attachments/assets/e77bb7ee-0205-48ed-8731-7cfdc1a207da" />

### Related

https://github.com/broadinstitute/terra-helmfile/pull/5922