### PR TITLE
[DT-3885] Add `report-to-sherlock` to the build process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,8 @@ name: Bump, Tag, and Publish
 # The purpose of the workflow is to:
 #  1. Bump the version number and tag the release if not a PR
 #  2. Build docker image and publish to GCR
+#  3. Report the new version to Sherlock (Broad DevOps' deployment tracker)
+#  4. On merge to main, set that version on the yale-terra-dev release and deploy it
 #
 # When run on merge to main, it tags and bumps the patch version by default. You can
 # bump other parts of the version by putting #major, #minor, or #patch in your commit
@@ -31,6 +33,8 @@ env:
 jobs:
   tag-publish-job:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     permissions:
       # Push changed tag
       contents: "write"
@@ -80,3 +84,97 @@ jobs:
 
       - name: Push image
         run: "docker push ${{ steps.image-name.outputs.name }}"
+
+  report-to-sherlock:
+    # Record the new Yale version with Broad DevOps so it shows up in Beehive and can be
+    # deployed to any environment or cluster that runs Yale.
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@b8bc16e5c447bd81f38eb78c18205c9f5af26902 # main
+    needs: [ tag-publish-job ]
+    with:
+      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      chart-name: 'yale'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  set-version-in-terra-dev:
+    # Put the new Yale version on the terra-dev cluster and deploy it.
+    #
+    # Yale is a cluster release rather than an app in a Terra environment, so Sherlock's
+    # client-set-environment-app-version.yaml reusable workflow can't be used here -- it
+    # addresses chart releases as "<environment>/<chart>", and Yale's are named
+    # "<chart>-<cluster>" (i.e. "yale-terra-dev"). This job does the same two things that
+    # workflow does, against that chart release: plan-and-apply an exact-version changeset
+    # in Sherlock, then dispatch terra-github-workflows to sync the release.
+    if: github.event_name == 'push'
+    needs: [ tag-publish-job, report-to-sherlock ]
+    runs-on: ubuntu-latest
+    permissions:
+      # Use OIDC -> IAP
+      id-token: 'write'
+    env:
+      SHERLOCK_PROD_URL: 'https://sherlock.dsp-devops-prod.broadinstitute.org'
+      BEEHIVE_PROD_VANITY_URL: 'https://broad.io/beehive'
+      CHART_RELEASE_NAME: 'yale-terra-dev'
+      NEW_VERSION: ${{ needs.tag-publish-job.outputs.tag }}
+    steps:
+      - name: Write changeset request body
+        run: |
+          jq -n \
+            --arg chartRelease "$CHART_RELEASE_NAME" \
+            --arg version "$NEW_VERSION" \
+            '{chartReleases: [{
+               chartRelease: $chartRelease,
+               toAppVersionResolver: "exact",
+               toAppVersionExact: $version
+             }]}' > "$RUNNER_TEMP/body.json"
+          cat "$RUNNER_TEMP/body.json"
+
+      - name: Authenticate to GCP for IAP
+        id: iap_auth
+        uses: google-github-actions/auth@v3
+        with:
+          # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
+          token_format: 'id_token'
+          id_token_audience: '257801540345-1gqi6qi66bjbssbv01horu9243el2r8b.apps.googleusercontent.com'
+          id_token_include_email: true
+          create_credentials_file: false
+          export_environment_variables: false
+
+      - name: Generate GHA OIDC token
+        id: gha_auth
+        uses: actions/github-script@v8
+        with:
+          script: core.setOutput('id_token', await core.getIDToken())
+
+      - name: Set app version in Sherlock
+        id: changesets
+        env:
+          IAP_TOKEN: ${{ steps.iap_auth.outputs.id_token }}
+          GHA_OIDC_TOKEN: ${{ steps.gha_auth.outputs.id_token }}
+        run: |
+          set -eo pipefail
+          curl --fail-with-body -X 'POST' \
+            "$SHERLOCK_PROD_URL/api/changesets/procedures/v3/plan-and-apply" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $IAP_TOKEN" \
+            -H "X-GHA-OIDC-JWT: $GHA_OIDC_TOKEN" \
+            -d "@$RUNNER_TEMP/body.json" | jq > "$RUNNER_TEMP/response.json"
+          cat "$RUNNER_TEMP/response.json"
+          echo "changesets=$(jq -r 'map(.id) | join(",")' "$RUNNER_TEMP/response.json")" >> $GITHUB_OUTPUT
+          echo "## Set $CHART_RELEASE_NAME to yale/$NEW_VERSION in Sherlock" >> $GITHUB_STEP_SUMMARY
+          echo "### Available in Beehive at $BEEHIVE_PROD_VANITY_URL/r/chart-release/$CHART_RELEASE_NAME" >> $GITHUB_STEP_SUMMARY
+
+      - name: Dispatch sync to terra-github-workflows
+        # An empty changeset list means Sherlock decided nothing needed to change, so there's
+        # nothing to deploy.
+        if: steps.changesets.outputs.changesets != ''
+        uses: broadinstitute/workflow-dispatch@v4
+        with:
+          repo: broadinstitute/terra-github-workflows
+          workflow: .github/workflows/sync-release.yaml
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }}
+          inputs: '{ "chart-release-names": "${{ env.CHART_RELEASE_NAME }}", "changeset-ids": "${{ steps.changesets.outputs.changesets }}", "refresh-only": "false" }'


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3885

## Summary
This updates `.github/workflows/build.yaml` to automate post-build release registration and terra-dev deployment.
1. Exposes `tag-publish-job`’s bumped tag as a job output (outputs.tag).
2. Adds a new `report-to-sherlock` job (reusable Sherlock workflow) to report the new Yale app version (chart-name: yale).
3. Adds a new `set-version-in-terra-dev` job (push to main only) that:
    - creates an exact-version Sherlock changeset for yale-terra-dev,
    - authenticates via GCP/IAP + GitHub OIDC,
    - calls Sherlock plan-and-apply,
    - dispatches `broadinstitute/terra-github-workflows/.github/workflows/sync-release.yaml` when changes are returned.

### Why
After image publish, Yale versions should automatically be tracked in Sherlock/Beehive and promoted to the `yale-terra-dev` chart release without manual deployment steps.

